### PR TITLE
Fix 2nd-pass bugs: docking, mission failure, gamepad reset, AI rewards, rendering

### DIFF
--- a/controllers/CollisionHandler.js
+++ b/controllers/CollisionHandler.js
@@ -325,11 +325,18 @@ class CollisionHandler {
                 rocketModel.landedOn = otherBody.label;
                 rocketModel.attachedTo = otherBody.label;
                 rocketModel.relativePosition = null;
-                
+                // Invariant : une fusée en cours de crash ne doit jamais rester "posée".
+                // Sans cela, si la fusée était isLanded=true juste avant l'impact, elle deviendrait
+                // isLanded=true ET isDestroyed=true la même frame, et handleLandedOrAttachedRocket
+                // appliquerait simultanément le cas "posé" et le cas "débris" (setPosition/setAngle/
+                // setVelocity concurrents). On force explicitement isLanded=false ici, sans dépendre
+                // du seul effet de bord d'applyDamage.
+                rocketModel.isLanded = false;
+
                 // Appliquer des dégâts fatals SI la fusée n'est pas déjà détruite
                 let wasJustDestroyedByCrash = false;
                 if (!rocketModel.isDestroyed) {
-                    wasJustDestroyedByCrash = rocketModel.applyDamage(this.ROCKET.MAX_HEALTH + 1); 
+                    wasJustDestroyedByCrash = rocketModel.applyDamage(this.ROCKET.MAX_HEALTH + 1);
                 }
                 
                 this.playCollisionSound(50);

--- a/controllers/GameController.js
+++ b/controllers/GameController.js
@@ -637,7 +637,7 @@ class GameController {
                 const rocketStartX = host.position.x + Math.cos(angleVersSoleil) * (host.radius + ROCKET.HEIGHT / 2 + 1);
                 const rocketStartY = host.position.y + Math.sin(angleVersSoleil) * (host.radius + ROCKET.HEIGHT / 2 + 1);
                 this.rocketModel.setPosition(rocketStartX, rocketStartY);
-                this.rocketModel.setVelocity(host.velocity.x, host.velocity.y);
+                this.rocketModel.setVelocity(host.velocity?.x || 0, host.velocity?.y || 0);
                 this.rocketModel.setAngle(angleVersSoleil);
                 this.rocketModel.isLanded = true;
                 this.rocketModel.landedOn = host.name;
@@ -846,7 +846,7 @@ class GameController {
         } else {
             console.warn("[GameController] physicsController.adjustGlobalThrustMultiplier n'est pas disponible.");
             // Fallback à l'ancienne logique si la méthode n'existe pas (pourrait être retiré plus tard)
-            const currentMultiplier = PHYSICS.THRUST_MULTIPLIER;
+            const currentMultiplier = PHYSICS.THRUST_MULTIPLIER ?? 1;
             const newMultiplier = currentMultiplier * factor;
             const minMultiplier = 0.1;
             const maxMultiplier = 1000;
@@ -866,9 +866,19 @@ class GameController {
      */
     handleRocketStateUpdated(data) {
         if (data.isDestroyed && !this._lastRocketDestroyed) {
-            // Une action pourrait être déclenchée ici si la fusée est détruite,
-            // comme afficher un message ou démarrer un timer de réinitialisation.
-            // Pour l'instant, seul l'état _lastRocketDestroyed est mis à jour.
+            // Transition de destruction détectée (une seule fois, pas à chaque frame).
+            // Faire échouer toutes les missions encore en attente : la fusée (et son cargo)
+            // est détruite. On émet EVENTS.MISSION.FAILED par mission pending, ce que
+            // MissionManager.failMission attend ({ mission, rocketModel }).
+            if (this.missionManager && typeof this.missionManager.getActiveMissions === 'function') {
+                const pendingMissions = this.missionManager.getActiveMissions();
+                pendingMissions.forEach(mission => {
+                    this.eventBus.emit(EVENTS.MISSION.FAILED, {
+                        mission,
+                        rocketModel: this.rocketModel
+                    });
+                });
+            }
         }
         this._lastRocketDestroyed = !!data.isDestroyed;
     }
@@ -945,7 +955,8 @@ class GameController {
                     const match = stationsOnHost.find(s => {
                         // normaliser l'écart angulaire dans [-PI, PI]
                         let diff = outwardAngle - s.angle;
-                        diff = (diff + Math.PI) % (Math.PI * 2) - Math.PI;
+                        // Normalisation robuste dans [-PI, PI] (le % JS garde le signe du dividende)
+                        diff = ((diff % (2 * Math.PI)) + 2 * Math.PI + Math.PI) % (2 * Math.PI) - Math.PI;
                         // Convertir tolérance de distance en tolérance angulaire approximative
                         const radius = host.radius - (typeof STATIONS !== 'undefined' && STATIONS.SURFACE_INSET !== undefined ? STATIONS.SURFACE_INSET : -(typeof STATIONS !== 'undefined' ? STATIONS.SURFACE_OFFSET : 4));
                         const baseTol = (typeof STATIONS !== 'undefined' ? STATIONS.DOCKING_DISTANCE_TOLERANCE : 40);
@@ -1036,6 +1047,23 @@ class GameController {
             return;
         }
         this._universeLoadInFlight = true;
+        // Mémoriser l'état précédent pour pouvoir le restaurer sur tout chemin d'échec
+        // (évite de rester bloqué en PAUSED avec menu pause et aucun monde).
+        const previousState = this.currentState;
+        // Indique si on a effectivement basculé en PAUSED et donc qu'il faut restaurer.
+        let pausedForLoad = false;
+        // Restaure un état cohérent après un échec de chargement.
+        const restoreAfterFailure = () => {
+            // Si aucun monde n'a jamais été chargé (modèles absents), on ne peut pas reprendre :
+            // on reste dans l'état précédent (typiquement LOADING).
+            const canResume = !!(this.rocketModel && this.universeModel);
+            if (this.physicsController) this.physicsController.resumeSimulation();
+            if (canResume) {
+                this.changeState(GameStates.PLAYING);
+            } else {
+                this.changeState(previousState);
+            }
+        };
         try {
             if (!opts || !opts.source) {
                 console.warn('[GameController] UNIVERSE_LOAD_REQUESTED sans options valides.');
@@ -1045,6 +1073,7 @@ class GameController {
             // Mettre en pause la simulation pour un reload sûr
             if (this.physicsController) this.physicsController.pauseSimulation();
             this.changeState(GameStates.PAUSED);
+            pausedForLoad = true;
 
             let data = null;
             if (opts.source === 'random') {
@@ -1052,18 +1081,24 @@ class GameController {
                     data = window.ProceduralGenerator.generate(opts.seed);
                 } else {
                     console.warn('[GameController] Aucun ProceduralGenerator détecté. Abandon du chargement random.');
+                    restoreAfterFailure();
                     return;
                 }
             } else if (opts.source === 'preset' && typeof opts.url === 'string') {
                 data = await fetch(opts.url).then(r => r.json());
             } else {
                 console.warn('[GameController] Options de chargement preset/random invalides.', opts);
+                restoreAfterFailure();
                 return;
             }
 
             this.resetWorld(data);
         } catch (e) {
             console.error('[GameController] handleUniverseLoadRequested erreur:', e);
+            // En cas d'échec (ex: fetch/JSON), ne pas rester bloqué en PAUSED sans monde.
+            if (pausedForLoad) {
+                restoreAfterFailure();
+            }
         } finally {
             this._universeLoadInFlight = false;
         }

--- a/controllers/GameSetupController.js
+++ b/controllers/GameSetupController.js
@@ -145,8 +145,17 @@ class GameSetupController {
 
         // Appliquer les paramètres physiques spécifiques au monde avant de créer UniverseModel
         try {
+            // Capturer une seule fois la valeur par défaut de PHYSICS.G (issue de constants.js)
+            // afin de pouvoir la restaurer quand un preset ne définit pas physics.G.
+            if (GameSetupController._defaultPhysicsG === undefined && typeof PHYSICS !== 'undefined' && typeof PHYSICS.G === 'number') {
+                GameSetupController._defaultPhysicsG = PHYSICS.G;
+            }
             if (data.physics && typeof data.physics.G === 'number') {
                 PHYSICS.G = data.physics.G;
+            } else if (typeof GameSetupController._defaultPhysicsG === 'number') {
+                // Aucun G dans le preset : restaurer la valeur par défaut (évite la persistance
+                // du G d'un monde précédent).
+                PHYSICS.G = GameSetupController._defaultPhysicsG;
             }
         } catch (e) {
             console.warn('[GameSetupController.buildWorldFromData] Impossible d\'appliquer physics.G depuis data:', e);

--- a/controllers/HeadlessRocketEnvironment.js
+++ b/controllers/HeadlessRocketEnvironment.js
@@ -631,7 +631,12 @@ class HeadlessRocketEnvironment {
                 // le potential-based shaping. On ne fait donc rien pour 'navigate' ici.
                 break;
             case 'orbit':
-                reward += this.calculateOrbitReward();
+                // CORRECTION (bug double-comptage): la récompense d'orbite (shaping zone/vitesse
+                // ET bonus de succès ORBIT_SUCCESS unique via _missionAlreadyRewardedThisEpisode)
+                // est calculée EXCLUSIVEMENT inline dans le switch principal de calculateReward().
+                // Rappeler calculateOrbitReward() ici comptabiliserait une 2e récompense de
+                // shaping (formule différente) à chaque step. On neutralise donc 'orbit' ici,
+                // de façon cohérente avec navigate/crash_moon (source unique par objectif).
                 break;
             case 'land':
                 reward += this.calculateLandingReward();
@@ -642,7 +647,11 @@ class HeadlessRocketEnvironment {
                 // deux fois (même si calculateCrashMoonReward est sans état).
                 break;
             case 'explore':
-                reward += this.calculateExplorationReward();
+                // CORRECTION (bug double-comptage): l'exploration (shaping mouvement/visite ET
+                // bonus de succès unique) est récompensée EXCLUSIVEMENT inline dans le switch
+                // principal de calculateReward(). Rappeler calculateExplorationReward() ici
+                // ajouterait une 2e récompense de shaping par step. On neutralise donc 'explore'
+                // ici, de façon cohérente avec navigate/crash_moon (source unique par objectif).
                 break;
         }
         

--- a/controllers/InputController.js
+++ b/controllers/InputController.js
@@ -265,31 +265,53 @@ class InputController {
     }
 
     _releaseAllActiveActions() {
-        if (!this.activeKeyActions || this.activeKeyActions.size === 0) return;
-        const stopEventByAction = {
-            thrustForward: EVENTS.ROCKET.THRUST_FORWARD_STOP,
-            boost: EVENTS.ROCKET.THRUST_FORWARD_STOP,
-            thrustBackward: EVENTS.ROCKET.THRUST_BACKWARD_STOP,
-            rotateLeft: EVENTS.ROCKET.ROTATE_LEFT_STOP,
-            rotateRight: EVENTS.ROCKET.ROTATE_RIGHT_STOP,
-        };
-        for (const actionKey of this.activeKeyActions) {
-            // Les clés clavier utilisent '-' (action-code), les clés gamepad utilisent '_'
-            // (ex: 'thrustForward_gamepad_boost'). On extrait le nom d'action avant le
-            // premier séparateur rencontré, quel qu'il soit, pour relâcher les deux types.
-            const dashIdx = actionKey.indexOf('-');
-            const underscoreIdx = actionKey.indexOf('_');
-            let sepIdx = -1;
-            if (dashIdx >= 0 && underscoreIdx >= 0) {
-                sepIdx = Math.min(dashIdx, underscoreIdx);
-            } else {
-                sepIdx = dashIdx >= 0 ? dashIdx : underscoreIdx;
+        if (this.activeKeyActions && this.activeKeyActions.size > 0) {
+            const stopEventByAction = {
+                thrustForward: EVENTS.ROCKET.THRUST_FORWARD_STOP,
+                boost: EVENTS.ROCKET.THRUST_FORWARD_STOP,
+                thrustBackward: EVENTS.ROCKET.THRUST_BACKWARD_STOP,
+                rotateLeft: EVENTS.ROCKET.ROTATE_LEFT_STOP,
+                rotateRight: EVENTS.ROCKET.ROTATE_RIGHT_STOP,
+            };
+            for (const actionKey of this.activeKeyActions) {
+                // Les clés clavier utilisent '-' (action-code), les clés gamepad utilisent '_'
+                // (ex: 'thrustForward_gamepad_boost'). On extrait le nom d'action avant le
+                // premier séparateur rencontré, quel qu'il soit, pour relâcher les deux types.
+                const dashIdx = actionKey.indexOf('-');
+                const underscoreIdx = actionKey.indexOf('_');
+                let sepIdx = -1;
+                if (dashIdx >= 0 && underscoreIdx >= 0) {
+                    sepIdx = Math.min(dashIdx, underscoreIdx);
+                } else {
+                    sepIdx = dashIdx >= 0 ? dashIdx : underscoreIdx;
+                }
+                const actionName = sepIdx >= 0 ? actionKey.slice(0, sepIdx) : actionKey;
+                const stopEvent = stopEventByAction[actionName];
+                if (stopEvent) this.eventBus.emit(stopEvent);
             }
-            const actionName = sepIdx >= 0 ? actionKey.slice(0, sepIdx) : actionKey;
-            const stopEvent = stopEventByAction[actionName];
-            if (stopEvent) this.eventBus.emit(stopEvent);
+            this.activeKeyActions.clear();
         }
-        this.activeKeyActions.clear();
+
+        // Régression gamepad : après avoir vidé activeKeyActions et émis les STOP, l'état
+        // mémorisé des boutons (gamepadState.buttons[i].pressed) reste à `true` pour un
+        // bouton physiquement maintenu. Au prochain update(), pressed === wasPressed → aucun
+        // front montant → START jamais ré-émis → propulseur bloqué OFF. On réinitialise donc
+        // l'état mémorisé : le prochain update() verra un front montant pour les boutons
+        // encore tenus et ré-émettra START. Le clavier n'est pas concerné (keyup le gère).
+        if (this.gamepadState && Array.isArray(this.gamepadState.buttons)) {
+            for (let i = 0; i < this.gamepadState.buttons.length; i++) {
+                if (this.gamepadState.buttons[i]) {
+                    this.gamepadState.buttons[i].pressed = false;
+                    this.gamepadState.buttons[i].value = 0;
+                }
+            }
+        }
+        // Idem pour les axes : on purge l'état mémorisé et on stoppe toute rotation en cours.
+        // Un axe encore maintenu sera de nouveau pris en compte au prochain update().
+        if (this.heldAxes && Object.keys(this.heldAxes).length > 0) {
+            this.heldAxes = {};
+            if (this.eventBus) this.eventBus.emit(EVENTS.INPUT.ROTATE_COMMAND, { value: 0 });
+        }
     }
     
     /**
@@ -393,7 +415,7 @@ class InputController {
         // Écouter les déconnexions futures
         const gpDisconnectHandler = (event) => {
             if (this.gamepad && this.gamepad.index === event.gamepad.index) {
-                this.disconnectGamepad(event.gamepad.id);
+                this.disconnectGamepad(event.gamepad);
             }
         };
         this._gamepadHandlers.disconnected = gpDisconnectHandler;
@@ -436,18 +458,22 @@ class InputController {
      * Gère la déconnexion d'une manette de jeu.
      * Réinitialise l'état de la manette dans le contrôleur.
      * Émet un événement `EVENTS.INPUT.GAMEPAD_DISCONNECTED`.
-     * @param {string} gamepadId - L'ID de la manette déconnectée, tel que fourni par l'API Gamepad.
+     * @param {Gamepad} gamepad - La manette déconnectée, telle que fournie par l'API Gamepad.
      */
-    disconnectGamepad(gamepadId) {
-        if (this.gamepad && this.gamepad.id === gamepadId) {
-            const index = this.gamepad.index;
+    disconnectGamepad(gamepad) {
+        // On compare par `index` (slot physique) pour rester cohérent avec le handler
+        // `gamepaddisconnected`. Comparer par `id` échouait quand une autre manette est
+        // branchée sur le même slot (même index, id différent) : `this.gamepad` n'était
+        // alors jamais libéré et `connectGamepad` rejetait le pad de remplacement.
+        if (this.gamepad && gamepad && this.gamepad.index === gamepad.index) {
+            const disconnectedId = this.gamepad.id;
             this.gamepad = null;
             this.gamepadState.axes.fill(0);
             this.gamepadState.buttons = Array.from({ length: this.gamepadState.buttons.length }, () => ({ pressed: false, value: 0 }));
             // Vider les axes maintenus et arrêter toute rotation en cours pour éviter une rotation bloquée.
             this.heldAxes = {};
             this.eventBus.emit(EVENTS.INPUT.ROTATE_COMMAND, { value: 0 });
-            this.eventBus.emit(EVENTS.INPUT.GAMEPAD_DISCONNECTED, { id: gamepadId });
+            this.eventBus.emit(EVENTS.INPUT.GAMEPAD_DISCONNECTED, { id: disconnectedId });
             this.noGamepadLogged = false; // Réinitialiser lors de la déconnexion
         }
     }

--- a/controllers/MissionManager.js
+++ b/controllers/MissionManager.js
@@ -183,7 +183,10 @@ class MissionManager {
                 console.warn('[MissionManager] Mission invalide ignorée:', m);
                 continue;
             }
-            const sanitized = m.requiredCargo.filter(it => it && typeof it.type === 'string' && typeof it.quantity === 'number' && it.quantity > 0);
+            const sanitized = m.requiredCargo
+                .filter(it => it && typeof it.type === 'string' && typeof it.quantity === 'number' && it.quantity > 0)
+                // Cloner chaque item pour éviter les références partagées avec les données source.
+                .map(it => ({ type: it.type, quantity: it.quantity }));
             if (sanitized.length === 0) {
                 console.warn('[MissionManager] requiredCargo vide/invalid pour mission, ignorée:', m);
                 continue;

--- a/controllers/ParticleController.js
+++ b/controllers/ParticleController.js
@@ -93,14 +93,9 @@ class ParticleController {
                 );
             }
 
-            // Fallback: déclencher aussi à la mise à jour des crédits (récompense mission)
-            if (window.EVENTS && window.EVENTS.UI && window.EVENTS.UI.CREDITS_UPDATED) {
-                window.controllerContainer.track(
-                    this.eventBus.subscribe(window.EVENTS.UI.CREDITS_UPDATED, () => {
-                        this._triggerMissionCelebration();
-                    })
-                );
-            }
+            // NOTE: la célébration est volontairement abonnée UNIQUEMENT à MISSION.COMPLETED.
+            // Coupler une célébration festive à UI.CREDITS_UPDATED était un piège : tout futur
+            // gain de crédits (hors mission) déclencherait une fausse célébration.
 
             // Suivre les dimensions du canvas pour positionner correctement les effets de célébration
             if (window.EVENTS && window.EVENTS.SYSTEM && window.EVENTS.SYSTEM.CANVAS_RESIZED) {

--- a/controllers/PhysicsVectors.js
+++ b/controllers/PhysicsVectors.js
@@ -212,14 +212,18 @@ class PhysicsVectors {
                 let thrustAngle = 0;
                 let thrustMagnitude = 0;
 
+                const effectiveness = rocketConstants.THRUSTER_EFFECTIVENESS || {};
+                const thrustMultiplier = (typeof PHYSICS !== 'undefined' ? PHYSICS.THRUST_MULTIPLIER : 1);
+                const powerRatio = thruster.maxPower > 0 ? thruster.power / thruster.maxPower : 0;
+
                 switch (thrusterName) {
                     case 'main':
                         thrustAngle = rocketModel.angle + Math.PI / 2; // Angle original de GameController
-                        thrustMagnitude = rocketConstants.MAIN_THRUST * (thruster.maxPower > 0 ? thruster.power / thruster.maxPower : 0) * (typeof PHYSICS !== 'undefined' ? PHYSICS.THRUST_MULTIPLIER : 1);
+                        thrustMagnitude = rocketConstants.MAIN_THRUST * powerRatio * (effectiveness.MAIN ?? 1) * thrustMultiplier;
                         break;
                     case 'rear':
                         thrustAngle = rocketModel.angle - Math.PI / 2; // Angle original de GameController
-                        thrustMagnitude = rocketConstants.REAR_THRUST * (thruster.maxPower > 0 ? thruster.power / thruster.maxPower : 0) * (typeof PHYSICS !== 'undefined' ? PHYSICS.THRUST_MULTIPLIER : 1);
+                        thrustMagnitude = rocketConstants.REAR_THRUST * powerRatio * (effectiveness.REAR ?? 1) * thrustMultiplier;
                         break;
                 }
 
@@ -228,8 +232,10 @@ class PhysicsVectors {
                         x: thruster.position.x,
                         y: thruster.position.y
                     },
-                    x: -Math.cos(thrustAngle), // Direction originale de GameController
-                    y: -Math.sin(thrustAngle), // Direction originale de GameController
+                    vector: {
+                        x: -Math.cos(thrustAngle), // Direction originale de GameController
+                        y: -Math.sin(thrustAngle)  // Direction originale de GameController
+                    },
                     magnitude: thrustMagnitude
                 };
             }

--- a/controllers/RenderingController.js
+++ b/controllers/RenderingController.js
@@ -250,7 +250,9 @@ class RenderingController {
                 if (typeof surfaceInset !== 'number' || isNaN(surfaceInset)) {
                     surfaceInset = DEFAULT_INSET;
                 }
-                const r = host.radius - surfaceInset;
+                // Borne à 0 : un inset supérieur au rayon (corps-hôte très petit) donnerait un
+                // rayon négatif, plaçant l'icône à l'opposé du centre.
+                const r = Math.max(0, host.radius - surfaceInset);
                 const worldX = host.position.x + Math.cos(st.angle) * r;
                 const worldY = host.position.y + Math.sin(st.angle) * r;
                 const screen = this.universeView.worldToScreen(worldX, worldY, camera);
@@ -360,7 +362,6 @@ class RenderingController {
             this.vectorsView.render(ctx, finalRocketStateForView, camera, {
                 showTotalThrustVector: true,
                 showVelocityVector: true,
-                showAccelerationVector: true,
                 showLunarAttractionVector: true,
                 showEarthAttractionVector: true,
                 showMissionStartVector: true,

--- a/controllers/SynchronizationManager.js
+++ b/controllers/SynchronizationManager.js
@@ -14,22 +14,23 @@ class SynchronizationManager {
         this.Events = this.physicsController.Events;
 
         // Synchronisation réactive des corps mobiles avant chaque update
-        this.Events.on(this.engine, 'beforeUpdate', () => {
+        // Je stocke le handler dans une propriété pour pouvoir le désabonner proprement (évite la fuite d'écouteurs au reload).
+        this._beforeUpdateHandler = () => {
             this.syncMovingBodyPositions();
             // Ne pas forcer la synchronisation du rocketModel vers physique en vol (éviter d'écraser la stabilisation)
             const rocketModel = this.physicsController.rocketModel;
             if (!rocketModel) return;
-            
+
             // CORRECTION: Ne pas synchroniser si:
             // 1. La fusée n'est pas atterrie (en vol)
             // 2. Le délai de grâce est actif (décollage récent)
             // 3. Le propulseur principal est actif (tentative de décollage)
-            const isInGracePeriod = rocketModel._liftoffGracePeriodEnd !== null && 
+            const isInGracePeriod = rocketModel._liftoffGracePeriodEnd !== null &&
                                     Date.now() < rocketModel._liftoffGracePeriodEnd;
             const main = rocketModel.thrusters && rocketModel.thrusters.main ? rocketModel.thrusters.main : null;
-            const isThrusterActive = main && main.maxPower > 0 && 
+            const isThrusterActive = main && main.maxPower > 0 &&
                                      (main.power / main.maxPower) * 100 > this.PHYSICS.TAKEOFF_THRUST_THRESHOLD_PERCENT;
-            
+
             // Ne synchroniser que si la fusée est vraiment posée (pas en décollage)
             if ((rocketModel.isLanded || rocketModel.isDestroyed) && !isInGracePeriod && !isThrusterActive) {
                 // CORRECTION BUG CRASH: Mettre à jour la position du modèle AVANT de synchroniser avec la physique
@@ -40,12 +41,21 @@ class SynchronizationManager {
                 // Log de debug pour tracer les cas où on évite la synchronisation
                 // console.log(`[beforeUpdate] Évite sync: gracePeriod=${isInGracePeriod}, thrusterActive=${isThrusterActive}`);
             }
-        });
+        };
+        this.Events.on(this.engine, 'beforeUpdate', this._beforeUpdateHandler);
 
         // Synchronisation réactive Physics → Model après chaque update (écouter l'engine, pas le world)
-        this.Events.on(this.engine, 'afterUpdate', () => {
+        this._afterUpdateHandler = () => {
             this.syncModelWithPhysics(this.physicsController.rocketModel);
-        });
+        };
+        this.Events.on(this.engine, 'afterUpdate', this._afterUpdateHandler);
+
+        // Enregistrer le désabonnement des écouteurs Matter.js pour le nettoyage centralisé.
+        // Sans cela, au rechargement d'univers ces écouteurs s'accumuleraient (fuite mémoire).
+        if (window.controllerContainer && typeof window.controllerContainer.track === 'function') {
+            window.controllerContainer.track(() => this.Events.off(this.engine, 'beforeUpdate', this._beforeUpdateHandler));
+            window.controllerContainer.track(() => this.Events.off(this.engine, 'afterUpdate', this._afterUpdateHandler));
+        }
 
         // CORRECTION: S'abonner à UNIVERSE_STATE_UPDATED pour réinitialiser les références après rechargement
         if (this.eventBus && window.EVENTS && window.EVENTS.UNIVERSE && window.EVENTS.UNIVERSE.STATE_UPDATED) {
@@ -59,6 +69,26 @@ class SynchronizationManager {
         }
 
         // Détection d'atterrissage gérée périodiquement via checkRocketLandedStatusPeriodically et CollisionHandler
+    }
+
+    /**
+     * Désabonne les écouteurs Matter.js (beforeUpdate/afterUpdate) pour éviter une fuite
+     * d'écouteurs cumulés (notamment au rechargement d'univers ou à un teardown).
+     * Idempotent : les références sont mises à null après retrait.
+     * Le nettoyage est aussi enregistré via controllerContainer.track() dans le constructeur ;
+     * cette méthode permet un nettoyage explicite cohérent avec les autres contrôleurs.
+     */
+    cleanup() {
+        if (this.Events && this.engine) {
+            if (this._beforeUpdateHandler) {
+                this.Events.off(this.engine, 'beforeUpdate', this._beforeUpdateHandler);
+                this._beforeUpdateHandler = null;
+            }
+            if (this._afterUpdateHandler) {
+                this.Events.off(this.engine, 'afterUpdate', this._afterUpdateHandler);
+                this._afterUpdateHandler = null;
+            }
+        }
     }
 
     // Synchronise le modèle logique avec les données du corps physique

--- a/controllers/TrainingOrchestrator.js
+++ b/controllers/TrainingOrchestrator.js
@@ -505,17 +505,18 @@ class TrainingOrchestrator {
                 break;
             }
             
-            // L'agent choisit une action
-            const action = this.getActionFromState(state);
-            
+            // L'agent choisit une action (sur l'environnement d'entraînement)
+            const action = this.getActionFromState(state, this.trainingEnv);
+
             // Exécuter l'action dans l'environnement
             const result = this.trainingEnv.step(action);
-            
+
             // Stocker l'expérience pour l'apprentissage
             if (this.rocketAI.isTraining) {
                 // Convertir les états au format attendu par RocketAI
-                const aiState = this.buildAIState(state);
-                const nextAIState = this.buildAIState(result.observation);
+                // CORRECTION (bug #2) : cible B résolue sur l'env d'entraînement.
+                const aiState = this.buildAIState(state, this.trainingEnv);
+                const nextAIState = this.buildAIState(result.observation, this.trainingEnv);
                 
                 this.rocketAI.replayBuffer.push({
                     state: aiState,
@@ -623,9 +624,10 @@ class TrainingOrchestrator {
     /**
      * Convertit l'observation en action via l'agent IA
      */
-    getActionFromState(state) {
+    getActionFromState(state, env = this.trainingEnv) {
         // Construire l'état pour l'agent IA (format attendu par RocketAI)
-        const aiState = this.buildAIState(state);
+        // CORRECTION (bug #2) : propager l'environnement courant pour résoudre la cible B.
+        const aiState = this.buildAIState(state, env);
         
         // Vérifier que l'agent est disponible et non dispose
         if (!this.rocketAI || this.rocketAI.isDisposed) {
@@ -646,8 +648,13 @@ class TrainingOrchestrator {
      * pour garantir une normalisation et une dimension (10) IDENTIQUES entre entraînement,
      * évaluation et inférence. L'état est CONSCIENT DE LA CIBLE B (pour 'navigate'), sinon
      * la cible vaut (0,0) (corps de référence à l'origine pour les autres objectifs headless).
+     * CORRECTION (bug #2) : la cible B est lue sur l'ENVIRONNEMENT COURANT passé en argument
+     * (trainingEnv en apprentissage, evaluationEnv en évaluation), et non plus toujours sur
+     * this.trainingEnv. this.config ne contient jamais missionConfig, c'est l'env qui le porte.
+     * @param {object} environmentState - L'observation brute renvoyée par l'environnement
+     * @param {HeadlessRocketEnvironment} [env] - L'environnement courant (défaut: trainingEnv)
      */
-    buildAIState(environmentState) {
+    buildAIState(environmentState, env = this.trainingEnv) {
         const STATE_SIZE = (typeof RocketAI !== 'undefined' && RocketAI.STATE_SIZE) ? RocketAI.STATE_SIZE : 10;
 
         // Vérifier que environmentState existe
@@ -656,8 +663,8 @@ class TrainingOrchestrator {
         }
 
         // Récupérer la cible : point B pour 'navigate', sinon origine (0,0)
-        const targetPoint = this.config?.missionConfig?.targetPoint
-            || (this.trainingEnv && this.trainingEnv.config?.missionConfig?.targetPoint)
+        // Source unique : la config de l'environnement courant.
+        const targetPoint = (env && env.config?.missionConfig?.targetPoint)
             || { x: 0, y: 0 };
 
         return RocketAI.buildStateVector({
@@ -728,7 +735,8 @@ class TrainingOrchestrator {
                 let steps = 0;
                 
                 while (!done && steps < this.config.maxStepsPerEpisode) {
-                    const action = this.getActionFromState(state);
+                    // CORRECTION (bug #2) : cible B résolue sur l'env d'évaluation.
+                    const action = this.getActionFromState(state, this.evaluationEnv);
                     const result = this.evaluationEnv.step(action);
                     
                     state = result.observation;

--- a/models/CameraModel.js
+++ b/models/CameraModel.js
@@ -126,9 +126,11 @@ class CameraModel {
         const targetX = this.target.position.x;
         const targetY = this.target.position.y;
         
-        // Interpolation linéaire pour un mouvement doux vers la cible.
-        const deltaX = (targetX - this.x) * this.smoothing * deltaTime;
-        const deltaY = (targetY - this.y) * this.smoothing * deltaTime;
+        // Interpolation exponentielle pour un mouvement doux vers la cible,
+        // indépendante du framerate. Le facteur reste dans [0, 1), évitant tout overshoot.
+        const factor = 1 - Math.exp(-this.smoothing * deltaTime);
+        const deltaX = (targetX - this.x) * factor;
+        const deltaY = (targetY - this.y) * factor;
 
         this.x += deltaX;
         this.y += deltaY;

--- a/models/RocketModel.js
+++ b/models/RocketModel.js
@@ -151,6 +151,11 @@ class RocketModel {
         // Réinitialiser l'état (santé, carburant)
         this.fuel = ROCKET.FUEL_MAX;
         this.health = ROCKET.MAX_HEALTH;
+        // Réaffirmer l'état par défaut du carburant infini pour éviter qu'un mode
+        // activé précédemment (entraînement 'navigate') ne fuie vers le jeu normal.
+        // HeadlessRocketEnvironment.reset() re-positionne ce flag selon sa config
+        // juste après l'appel à reset(), donc l'entraînement n'est pas impacté.
+        this._infiniteFuel = false;
         this.isDestroyed = false;
         this.isLanded = false;
         this.landedOn = null;

--- a/models/UniverseModel.js
+++ b/models/UniverseModel.js
@@ -212,6 +212,10 @@ class UniverseModel {
     reset(config = {}) {
         this.celestialBodies = [];
         this.stars = [];
+        this.asteroids = [];
+        this.stations = [];
+        this.narratives = {};
+        this.spawnInfo = null;
         this.elapsedTime = 0;
         this.initializeStars();
         // Logique future potentielle :

--- a/views/CelestialBodyView.js
+++ b/views/CelestialBodyView.js
@@ -56,13 +56,14 @@ class CelestialBodyView {
         const screenPos = camera.worldToScreen(body.position.x, body.position.y);
         const screenRadius = body.radius * camera.zoom;
 
-        // Détection générique de l'étoile centrale (multi-mondes) : c'est soit le corps
-        // identifié comme étoile par UniverseView (sunBodyModel), soit un corps portant un
-        // nom d'étoile connu, soit un corps sans parent (parentBody === null).
+        // Détection de l'étoile centrale (multi-mondes). Dès qu'UniverseView identifie une
+        // étoile centrale (sunBodyModel), un SEUL corps doit être rendu comme étoile : on
+        // teste l'identité stricte. Sans étoile fournie, on retombe sur l'heuristique par nom
+        // connu ou par absence de parent (corps racine).
         const STAR_NAMES = ['Soleil', 'Sun', 'Kerbol', 'Star', 'Sol'];
-        const isStar = (sunBodyModel && body === sunBodyModel) ||
-                       STAR_NAMES.includes(body.name) ||
-                       body.parentBody === null;
+        const isStar = sunBodyModel
+                       ? (body === sunBodyModel)
+                       : (STAR_NAMES.includes(body.name) || body.parentBody === null);
 
         // Effet spécial pour l'étoile centrale : dégradé radial animé du orange au jaune
         if (isStar) {

--- a/views/RocketView.js
+++ b/views/RocketView.js
@@ -71,7 +71,10 @@ class RocketView {
             try {
                 // Calculer les dimensions de dessin pour assurer une taille minimale à l'écran
                 const minScreenSize = 10; // Taille minimale souhaitée en pixels à l'écran
-                const minDrawDim = minScreenSize / camera.zoom; // Taille minimale équivalente dans les coordonnées du monde
+                // Garde défensive : éviter une division par zéro (zoom normalement borné ≥ 0.0025,
+                // mais un zoom à 0 produirait Infinity puis un drawImage de dimensions infinies).
+                const safeZoom = camera.zoom > 0 ? camera.zoom : 1;
+                const minDrawDim = minScreenSize / safeZoom; // Taille minimale équivalente dans les coordonnées du monde
 
                 let drawWidth = this.baseWidth;
                 let drawHeight = this.baseHeight;

--- a/views/StationView.js
+++ b/views/StationView.js
@@ -54,44 +54,33 @@ class StationView {
 
         // L'affichage du nom des stations est piloté par UI_STATE.showStations
         const showLabels = (typeof window !== 'undefined' && window.UI_STATE && window.UI_STATE.showStations) ? true : false;
-        if (name && showLabels) {
+        if (name && typeof name === 'string' && showLabels) {
             // Simplifier le nom: garder la partie avant le premier tiret
+            const parts = name.split('-');
             let base = name;
-            if (typeof name === 'string') {
-                const parts = name.split('-');
-                if (parts.length > 0) {
-                    base = parts[0] || name;
-                }
-                // Déterminer un suffixe numérique si le nom encode plusieurs stations (ex: Terre-Station-A / -B / -3)
-                let suffix = '';
-                const last = parts[parts.length - 1];
-                const prev = parts.length >= 2 ? parts[parts.length - 2] : '';
-                if (/^[A-Z]$/.test(last)) {
-                    // Lettre unique -> numéro (A→1, B→2, ...)
-                    suffix = String(last.charCodeAt(0) - 64);
-                } else if (/^\d+$/.test(last)) {
-                    suffix = last;
-                } else if (/^Station$/i.test(last) && /^[A-Z]$/.test(prev)) {
-                    suffix = String(prev.charCodeAt(0) - 64);
-                }
-                // Concaténer sans espace entre l'icône et le nom
-                const display = `⛽${base}${suffix}`;
-                ctx.save();
-                ctx.font = `${Math.max(10, size)}px Arial`;
-                ctx.fillStyle = 'white';
-                ctx.textAlign = 'center';
-                ctx.textBaseline = 'top';
-                ctx.fillText(display, x, y + size * 0.8);
-                ctx.restore();
-                return;
+            if (parts.length > 0) {
+                base = parts[0] || name;
             }
-            const fallbackDisplay = `⛽${base}`;
+            // Déterminer un suffixe numérique si le nom encode plusieurs stations (ex: Terre-Station-A / -B / -3)
+            let suffix = '';
+            const last = parts[parts.length - 1];
+            const prev = parts.length >= 2 ? parts[parts.length - 2] : '';
+            if (/^[A-Z]$/.test(last)) {
+                // Lettre unique -> numéro (A→1, B→2, ...)
+                suffix = String(last.charCodeAt(0) - 64);
+            } else if (/^\d+$/.test(last)) {
+                suffix = last;
+            } else if (/^Station$/i.test(last) && /^[A-Z]$/.test(prev)) {
+                suffix = String(prev.charCodeAt(0) - 64);
+            }
+            // Concaténer sans espace entre l'icône et le nom
+            const display = `⛽${base}${suffix}`;
             ctx.save();
             ctx.font = `${Math.max(10, size)}px Arial`;
             ctx.fillStyle = 'white';
             ctx.textAlign = 'center';
             ctx.textBaseline = 'top';
-            ctx.fillText(fallbackDisplay, x, y + size * 0.8);
+            ctx.fillText(display, x, y + size * 0.8);
             ctx.restore();
         }
     }

--- a/views/VectorsView.js
+++ b/views/VectorsView.js
@@ -36,7 +36,19 @@ class VectorsView {
     computeGravityFieldGrid(ctx, camera, physicsController) {
         // Throttle/reuse: ne recalculer que si la caméra a sensiblement changé ou si intervalle écoulé
         const now = performance && performance.now ? performance.now() : Date.now();
-        const sig = `${camera.x.toFixed(1)}|${camera.y.toFixed(1)}|${camera.zoom.toFixed(3)}|${ctx.canvas.width}|${ctx.canvas.height}`;
+        // Hash léger des positions des corps : la signature caméra seule ne suffit pas, car les
+        // corps orbitent même quand la caméra est immobile — sinon les flèches/équipotentielles
+        // resteraient figées et décalées pendant la fenêtre de throttle. On somme x+y de chaque
+        // corps pour détecter tout mouvement significatif et invalider le cache en conséquence.
+        let bodiesHash = 0;
+        const sigBodies = physicsController ? physicsController.celestialBodies : null;
+        if (sigBodies) {
+            for (const bodyInfo of sigBodies) {
+                const m = bodyInfo.model;
+                if (m && m.position) bodiesHash += m.position.x + m.position.y;
+            }
+        }
+        const sig = `${camera.x.toFixed(1)}|${camera.y.toFixed(1)}|${camera.zoom.toFixed(3)}|${ctx.canvas.width}|${ctx.canvas.height}|${bodiesHash.toFixed(1)}`;
         const canReuse = this.gravityFieldGrid && this._lastCameraSignature === sig && (now - this._lastGridComputeTime) < this._gridComputeIntervalMs;
         if (canReuse) {
             return; // Réutiliser la grille existante


### PR DESCRIPTION
## Résumé

Deuxième passe de chasse aux bugs (sur le code déjà corrigé par la PR #4), réalisée par 7 agents d'audit puis 6 agents correcteurs, un par domaine. Tous les fichiers passent `node --check`.

### Corrections majeures (fonctionnelles)
- **Angle de docking** (`GameController`) : normalisation robuste dans `[-π,π]` — le ravitaillement station échouait selon l'orientation.
- **Échec de mission** : `MISSION.FAILED` est désormais émis à la destruction de la fusée, ce qui active la restitution du cargo (handler jusque-là inerte).
- **Chargement d'univers** : restauration d'un état cohérent sur échec de `fetch`/options invalides (plus d'état PAUSED orphelin).
- **`PHYSICS.G`** restauré à sa valeur par défaut quand un preset ne le définit pas.
- **Récompenses IA** : fin du double comptage pour les objectifs `orbit` et `explore`.

### Robustesse
- **Gamepad** : reset de l'état des boutons sur `ROCKET.RESET`/blur (plus de propulseur bloqué OFF) ; déconnexion cohérente par `index` (gamepad de remplacement reconnu).
- **`RocketModel.reset()`** réinitialise `_infiniteFuel`.
- **PhysicsVectors** : `calculateThrustVectors` retourne `{vector, magnitude}` (flèches de poussée à nouveau dessinées) + `THRUSTER_EFFECTIVENESS`.
- **CollisionHandler** : `isLanded` remis à false au crash ; **SynchronizationManager** : `cleanup()` (off des handlers Matter.js).
- **Rendu** : garde `zoom===0` (RocketView), détection générique d'étoile (CelestialBodyView), invalidation du cache du champ de gravité quand les corps orbitent (VectorsView), rayon de station borné, suppression de code mort.
- **TrainingOrchestrator** : `buildAIState` reçoit l'env actif (cible B correcte en évaluation).
- **UniverseModel.reset()** vide aussi `asteroids/stations/narratives/spawnInfo`.
- **CameraModel** : lissage indépendant du framerate.
- **MissionManager/ParticleController** : clonage des items `requiredCargo` ; célébration découplée de `CREDITS_UPDATED`.

https://claude.ai/code/session_01ThZpyRxqQ7tv1azecTCVJZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThZpyRxqQ7tv1azecTCVJZ)_