### PR TITLE
Fix takeoff/landing velocity unit mismatch (relative to celestial body)

### DIFF
--- a/controllers/CollisionHandler.js
+++ b/controllers/CollisionHandler.js
@@ -248,12 +248,22 @@ class CollisionHandler {
      */
     getCelestialBodyVelocity(otherBody) {
         if (otherBody && this.physicsController && Array.isArray(this.physicsController.celestialBodies)) {
-            const info = this.physicsController.celestialBodies.find(cb => cb.body === otherBody);
+            // Résolution par référence du corps physique, avec repli par nom/label : la
+            // vérification périodique (SynchronizationManager) passe un objet corps SYNTHÉTIQUE
+            // qui n'est jamais === cb.body ; sans le repli par label, la vélocité retomberait à 0
+            // et la détection redeviendrait absolue au lieu de relative.
+            let info = this.physicsController.celestialBodies.find(cb => cb.body === otherBody);
+            if (!info && otherBody.label) {
+                info = this.physicsController.celestialBodies.find(cb => cb.model && cb.model.name === otherBody.label);
+            }
             if (info && info.model && info.model.velocity) {
-                return { x: info.model.velocity.x || 0, y: info.model.velocity.y || 0 };
+                // model.velocity est en unités/seconde (vélocité orbitale). On la convertit en
+                // déplacement par pas de simulation pour la comparer à rocketBody.velocity (Matter.js).
+                const dt = (this.physicsController.lastDeltaTime) || (1 / 60);
+                return { x: (info.model.velocity.x || 0) * dt, y: (info.model.velocity.y || 0) * dt };
             }
         }
-        // Repli : vélocité du corps physique uniquement s'il est dynamique, sinon zéro.
+        // Repli : la vélocité d'un corps physique dynamique est déjà en unités Matter (par pas).
         if (otherBody && otherBody.velocity && !otherBody.isStatic) {
             return { x: otherBody.velocity.x || 0, y: otherBody.velocity.y || 0 };
         }

--- a/controllers/PhysicsController.js
+++ b/controllers/PhysicsController.js
@@ -40,6 +40,10 @@ class PhysicsController {
 
         // Paramètres de simulation
         this.timeScale = 1.0;
+        // Dernier deltaTime (secondes) du tick courant. Sert à convertir les vélocités du
+        // modèle (exprimées en unités/seconde, ex. vélocité orbitale) vers le déplacement
+        // par pas de simulation utilisé par Matter.js (rocketBody.velocity).
+        this.lastDeltaTime = 1 / 60;
         this.gravitationalConstant = this.PHYSICS.G; // Correction : utiliser la même constante que la simulation
 
         // Contrôles assistés (l'état est géré ici, la logique dans ThrusterPhysics)
@@ -164,6 +168,9 @@ class PhysicsController {
         }
 
         this.clearCacheIfNeeded();
+
+        // Mémoriser le deltaTime courant pour les conversions vélocité modèle (u/s) → Matter (par pas).
+        this.lastDeltaTime = deltaTime;
 
         if (!this.rocketModel || !this.rocketBody || !this.universeModel) return;
 

--- a/controllers/SynchronizationManager.js
+++ b/controllers/SynchronizationManager.js
@@ -215,7 +215,14 @@ class SynchronizationManager {
                     // --- STABILISATION ACTIVE (Pas de tentative de décollage) ---
                     // Détecter si le corps est mobile (orbite)
                     const isMobile = landedOnModel.parentBody !== null;
-                    const parentVelocity = isMobile ? landedOnModel.velocity : { x: 0, y: 0 }; // Obtenir la vélocité du corps parent (ou zéro si statique)
+                    // model.velocity est en unités/seconde ; Matter.js (rocketBody.velocity) et la
+                    // vélocité de la fusée en vol sont en déplacement PAR PAS. On convertit (× dt)
+                    // pour que la fusée posée partage exactement le mouvement par pas de la planète
+                    // (et que handleLiftoff, qui applique la même conversion, soit cohérent au décollage).
+                    const dt = (this.physicsController && this.physicsController.lastDeltaTime) || (1 / 60);
+                    const parentVelocity = isMobile
+                        ? { x: (landedOnModel.velocity.x || 0) * dt, y: (landedOnModel.velocity.y || 0) * dt }
+                        : { x: 0, y: 0 };
 
                     // 1. Forcer les vitesses (Physique)
                     // Faire suivre la vélocité du corps parent pour les corps mobiles
@@ -288,7 +295,11 @@ class SynchronizationManager {
 
             // Vérifier si le corps est mobile (orbite) - Correction du test ici
             const isAttachedToMobile = attachedToModel && attachedToModel.parentBody !== null;
-            const parentVelocity = isAttachedToMobile ? attachedToModel.velocity : { x: 0, y: 0 };
+            // model.velocity (u/s) → déplacement par pas pour Matter.js (cf. CAS 1).
+            const dtAttached = (this.physicsController && this.physicsController.lastDeltaTime) || (1 / 60);
+            const parentVelocity = isAttachedToMobile
+                ? { x: (attachedToModel.velocity.x || 0) * dtAttached, y: (attachedToModel.velocity.y || 0) * dtAttached }
+                : { x: 0, y: 0 };
 
             if (isAttachedToMobile) {
                 // Calculer la position relative si pas encore fait

--- a/controllers/ThrusterPhysics.js
+++ b/controllers/ThrusterPhysics.js
@@ -172,11 +172,16 @@ class ThrusterPhysics {
                 cb => cb.model && cb.model.name === landedOnBodyName
             );
             if (celestialBodyInfo && celestialBodyInfo.model && celestialBodyInfo.model.velocity) {
+                // model.velocity est en unités/seconde (vélocité orbitale du corps). La vélocité
+                // d'un corps Matter.js (rocketBody) est un déplacement PAR PAS de simulation. On
+                // convertit donc (× deltaTime), sinon la fusée hériterait d'une vitesse ~60× trop
+                // grande et le décollage ne serait pas relatif à la planète.
+                const dt = (this.physicsController && this.physicsController.lastDeltaTime) || (1 / 60);
                 inheritedVelocity = {
-                    x: celestialBodyInfo.model.velocity.x || 0,
-                    y: celestialBodyInfo.model.velocity.y || 0
+                    x: (celestialBodyInfo.model.velocity.x || 0) * dt,
+                    y: (celestialBodyInfo.model.velocity.y || 0) * dt
                 };
-                console.log(`[LIFTOFF] Vélocité héritée de ${landedOnBodyName}: (${inheritedVelocity.x.toFixed(2)}, ${inheritedVelocity.y.toFixed(2)})`);
+                console.log(`[LIFTOFF] Vélocité héritée de ${landedOnBodyName} (par pas): (${inheritedVelocity.x.toFixed(3)}, ${inheritedVelocity.y.toFixed(3)})`);
             }
         }
 


### PR DESCRIPTION
## Résumé

Corrige un bug d'unités qui rendait le **décollage non relatif à la planète** (signalé sur Âtrebois, monde Outer Wilds).

### Cause
- Les corps célestes bougent de façon **cinématique** : `updateOrbit` les déplace de `model.velocity × deltaTime` par pas → `model.velocity` est en **unités/seconde** (Âtrebois ≈ 72 u/s).
- La fusée est intégrée par **Matter.js** (Verlet) : `position += body.velocity` par pas → `body.velocity` est un **déplacement par pas** (≈ vitesse/s × deltaTime).

Le décollage (et la stabilisation posée) injectaient les ~72 u/s **directement comme déplacement par pas** → la fusée partait à ~4320 px/s, soit ~60× la vitesse réelle de la planète.

### Correctif (`× deltaTime` à chaque transfert de vélocité corps → fusée)
- `PhysicsController` : mémorise `lastDeltaTime` à chaque tick.
- `ThrusterPhysics.handleLiftoff` : vélocité héritée `× deltaTime`.
- `SynchronizationManager` : stabilisation posée/attachée `× deltaTime`.
- `CollisionHandler.getCelestialBodyVelocity` : renvoie `model.velocity × deltaTime` (détection atterrissage/crash relative dans la bonne unité) + résolution du corps par nom en secours (corrige aussi la vérification d'atterrissage périodique qui passait un objet corps synthétique et retombait en vitesse absolue).

`node --check` OK sur les 4 fichiers.

https://claude.ai/code/session_01ThZpyRxqQ7tv1azecTCVJZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThZpyRxqQ7tv1azecTCVJZ)_