### PR TITLE
Fix liftoff kick direction (was pushing the rocket into the planet)

### DIFF
--- a/controllers/ThrusterPhysics.js
+++ b/controllers/ThrusterPhysics.js
@@ -191,24 +191,31 @@ class ThrusterPhysics {
         rocketModel.relativePosition = null;
         rocketModel.startLiftoffGracePeriod(500);
 
-        // L'angle "vers le haut" de la fusée est son angle - 90 degrés (PI/2 radians)
+        // L'axe "vers le haut" de la fusée (direction du nez / poussée principale) est `angle - PI/2`,
+        // exactement la direction de poussée du propulseur principal (cf. applyThrusterForce :
+        // thrustAngle = angle + MAIN.angle, avec MAIN.angle = -PI/2, force POSITIVE). Le coup de pouce
+        // de décollage doit donc être POSITIF dans cette direction (vers l'extérieur du corps).
+        // NB : un signe négatif ici poussait la fusée VERS le centre de la planète ; le bug était
+        // masqué par l'ancienne vélocité héritée (en mauvaises unités, ~60× trop grande) qui
+        // catapultait la fusée tangentiellement. Une fois la vélocité héritée corrigée, ce kick
+        // inversé plaquait la fusée au sol ("collée").
         const liftOffAngle = rocketBody.angle - Math.PI / 2;
-        
-        // Appliquer une impulsion modérée pour aider à vaincre l'inertie initiale
-        // La poussée continue des propulseurs fera le reste
+
+        // Appliquer une impulsion modérée (vers l'extérieur) pour aider à vaincre l'inertie initiale.
+        // La poussée continue des propulseurs fera le reste.
         const impulseForce = 50.0;
         const impulse = {
-            x: Math.cos(liftOffAngle) * -impulseForce,
-            y: Math.sin(liftOffAngle) * -impulseForce
+            x: Math.cos(liftOffAngle) * impulseForce,
+            y: Math.sin(liftOffAngle) * impulseForce
         };
         this.Body.applyForce(rocketBody, rocketBody.position, impulse);
 
-        // CORRECTION BUG INERTIE: Ajouter la vélocité héritée du corps céleste
-        // à la vitesse initiale de décollage pour conserver l'inertie
+        // CORRECTION BUG INERTIE: Ajouter la vélocité héritée du corps céleste (en déplacement par
+        // pas) à la vitesse initiale de décollage pour conserver l'inertie orbitale (décollage relatif).
         const initialVelMagnitude = 20.0;
         const liftoffVelocity = {
-            x: Math.cos(liftOffAngle) * -initialVelMagnitude + inheritedVelocity.x,
-            y: Math.sin(liftOffAngle) * -initialVelMagnitude + inheritedVelocity.y
+            x: Math.cos(liftOffAngle) * initialVelMagnitude + inheritedVelocity.x,
+            y: Math.sin(liftOffAngle) * initialVelMagnitude + inheritedVelocity.y
         };
         this.Body.setVelocity(rocketBody, liftoffVelocity);
         


### PR DESCRIPTION
## Résumé

Corrige le décollage qui plaquait la fusée au sol (« collée à la planète », ex. Âtrebois).

### Cause
`handleLiftoff` appliquait son impulsion et sa vélocité initiale le long de `(cos, sin)(liftOffAngle)` avec une magnitude **négative**. Or `liftOffAngle = angle − π/2` est exactement la direction de poussée du propulseur principal (`applyThrusterForce` utilise `MAIN.angle = −π/2` avec une force **positive**), qui pointe **vers l'extérieur** du corps pour une fusée posée. Le signe négatif poussait donc la fusée **vers le centre** de la planète.

Ce bug était masqué par l'ancienne vélocité héritée surdimensionnée (mauvaises unités, ~60×, corrigée en #7) qui catapultait la fusée tangentiellement. Une fois cette vélocité rendue réellement relative, le kick radial inversé est devenu dominant et plaquait la fusée à la surface.

### Correctif
Inverser le signe de l'impulsion et de la vélocité initiale de décollage pour pousser **vers l'extérieur**, en cohérence avec le propulseur principal.

`node --check` OK.

https://claude.ai/code/session_01ThZpyRxqQ7tv1azecTCVJZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThZpyRxqQ7tv1azecTCVJZ)_