### PR TITLE
Fix rocket re-gluing to moving bodies on takeoff (+ liftoff diagnostic)

### DIFF
--- a/controllers/CollisionHandler.js
+++ b/controllers/CollisionHandler.js
@@ -277,6 +277,16 @@ class CollisionHandler {
             return false;
         }
 
+        // Pendant la période de grâce de décollage, ne JAMAIS considérer la fusée comme posée.
+        // Sur un corps EN MOUVEMENT, la fusée qui décolle suit presque l'orbite du corps, donc sa
+        // vitesse RELATIVE reste faible : sans cette garde, isRocketLanded re-détecterait un
+        // atterrissage, isLanded serait ré-armé, et la stabilisation ré-ancrerait la fusée sur la
+        // surface mobile ("collée à la planète"). La grâce étant rafraîchie tant que le propulseur
+        // pousse, cette protection couvre tout le décollage + 500 ms après l'arrêt de la poussée.
+        if (typeof rocketModel.isInLiftoffGracePeriod === 'function' && rocketModel.isInLiftoffGracePeriod()) {
+            return false;
+        }
+
         // Si le modèle indique déjà un atterrissage sur ce corps, on considère que c'est toujours le cas.
         // Cela évite des calculs redondants ou des changements d'état rapides.
         if (rocketModel.isLanded && rocketModel.landedOn === otherBody.label) {

--- a/controllers/PhysicsController.js
+++ b/controllers/PhysicsController.js
@@ -221,6 +221,40 @@ class PhysicsController {
 
         // 7. Vérification périodique de l'état d'atterrissage
         this.synchronizationManager.checkRocketLandedStatusPeriodically(this.rocketModel, this.universeModel);
+
+        // --- DIAGNOSTIC DÉCOLLAGE (activable : window.DEBUG_LIFTOFF = true dans la console) ---
+        // Trace, ~6x/seconde, l'état de la fusée par rapport à son corps hôte/le plus proche, pour
+        // diagnostiquer un décollage qui échoue (fusée "collée"). N'a aucun effet si le flag est faux.
+        if (typeof window !== 'undefined' && window.DEBUG_LIFTOFF && this.rocketBody && this.rocketModel) {
+            this._dbgLiftoffFrame = (this._dbgLiftoffFrame || 0) + 1;
+            if (this._dbgLiftoffFrame % 10 === 0) {
+                const rm = this.rocketModel;
+                const rb = this.rocketBody;
+                // Corps de référence : celui sur lequel on est posé, sinon le plus proche.
+                let ref = this.celestialBodies.find(cb => cb.model && (cb.model.name === rm.landedOn || cb.model.name === rm.attachedTo));
+                if (!ref && this.celestialBodies.length) {
+                    ref = this.celestialBodies.reduce((best, cb) => {
+                        if (!cb.model || !cb.model.position) return best;
+                        const d = Math.hypot(rb.position.x - cb.model.position.x, rb.position.y - cb.model.position.y);
+                        return (!best || d < best._d) ? Object.assign({ _d: d }, cb) : best;
+                    }, null);
+                }
+                const main = rm.thrusters && rm.thrusters.main ? rm.thrusters.main : null;
+                const pct = main && main.maxPower > 0 ? ((main.power / main.maxPower) * 100).toFixed(0) : '0';
+                let info = '';
+                if (ref && ref.model && ref.model.position) {
+                    const bx = ref.model.position.x, by = ref.model.position.y;
+                    const dist = Math.hypot(rb.position.x - bx, rb.position.y - by);
+                    const bodyR = ref.model.radius || 0;
+                    const distSurf = (dist - bodyR).toFixed(1);
+                    const relvx = (rb.velocity.x - (ref.model.velocity ? ref.model.velocity.x * this.lastDeltaTime : 0)).toFixed(2);
+                    const relvy = (rb.velocity.y - (ref.model.velocity ? ref.model.velocity.y * this.lastDeltaTime : 0)).toFixed(2);
+                    info = `body=${ref.model.name} distSurf=${distSurf} relV=(${relvx},${relvy})`;
+                }
+                console.log(`[LIFTOFF-DBG] isLanded=${rm.isLanded} landedOn=${rm.landedOn} thrust=${pct}% grace=${rm.isInLiftoffGracePeriod && rm.isInLiftoffGracePeriod()} ` +
+                            `bodyVel(${rb.velocity.x.toFixed(2)},${rb.velocity.y.toFixed(2)}) handledManually=${isHandledManually} ${info}`);
+            }
+        }
     }
 
     // Calculer la force gravitationnelle totale pour la visualisation (debug)

--- a/controllers/SynchronizationManager.js
+++ b/controllers/SynchronizationManager.js
@@ -198,6 +198,11 @@ class SynchronizationManager {
                         this.physicsController.thrusterPhysics.handleLiftoff(rocketModel, this.physicsController.rocketBody, savedLandedOn);
                     }
                 }
+                // Rafraîchir la période de grâce À CHAQUE frame où la poussée est active (pas seulement
+                // à la transition). Combiné à isRocketLanded qui renvoie false pendant la grâce, cela
+                // empêche toute re-détection d'atterrissage / ré-ancrage pendant tout le décollage et
+                // 500 ms après l'arrêt de la poussée — y compris sur un corps en mouvement (Âtrebois).
+                rocketModel.startLiftoffGracePeriod(500);
                 return; // Ne pas appliquer la stabilisation si on essaie de décoller
             }
         }

--- a/models/RocketModel.js
+++ b/models/RocketModel.js
@@ -238,6 +238,16 @@ class RocketModel {
     startLiftoffGracePeriod(durationMs = 500) {
         this._liftoffGracePeriodEnd = Date.now() + durationMs;
     }
+
+    /**
+     * Indique si la période de grâce de décollage est active (lecture seule, sans effet de bord).
+     * Pendant cette période, la fusée ne doit JAMAIS être considérée comme posée (évite le
+     * re-collage immédiat sur un corps en mouvement où la vitesse relative reste faible).
+     * @returns {boolean}
+     */
+    isInLiftoffGracePeriod() {
+        return this._liftoffGracePeriodEnd !== null && Date.now() < this._liftoffGracePeriodEnd;
+    }
     
     /**
      * Vérifie si on peut mettre isLanded à true (pas de délai de grâce actif).


### PR DESCRIPTION
## Résumé

Corrige le re-collage de la fusée sur les corps célestes **en mouvement** au décollage (« collée à la planète », ex. Âtrebois). Ajoute aussi un diagnostic activable.

### Cause racine (trace frame-par-frame)
Sur un corps qui orbite réellement (Âtrebois ; la Terre a `orbitSpeed: 0` donc est immobile → décollage OK) :
1. La fusée décolle lentement → sa vitesse **relative** au corps reste faible.
2. `isRocketLanded` la re-détecte comme « posée » (vitesse relative faible + proche de la surface).
3. `isLanded` est ré-armé → la stabilisation des corps mobiles ré-ancre la position via `updateAbsolutePosition` + `setPosition`.
4. → re-collage à chaque frame.

Le correctif précédent (vitesse relative correcte, #7) a rendu cette re-détection plus permissive sur corps mobile. Le sens du kick (#8) et la conversion d'unités sont corrects et ne sont pas la cause.

### Correctif
Fermer la boucle : pendant la poussée **et 500 ms après**, la fusée ne peut plus être considérée comme posée.
- `RocketModel.isInLiftoffGracePeriod()` (lecture seule).
- `CollisionHandler.isRocketLanded` renvoie `false` pendant la période de grâce de décollage.
- `SynchronizationManager` rafraîchit la grâce à chaque frame où le propulseur principal pousse (pas seulement à la transition) → couvre tout le décollage + 500 ms.

### Diagnostic
Trace activable via `window.DEBUG_LIFTOFF = true` (désactivée par défaut, sans effet sinon) qui logge l'état de la fusée vs son corps hôte/le plus proche, pour confirmer le comportement runtime si besoin.

`node --check` OK sur les 4 fichiers.

https://claude.ai/code/session_01ThZpyRxqQ7tv1azecTCVJZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThZpyRxqQ7tv1azecTCVJZ)_