### PR TITLE
Fix décollage sur Âtrebois + rééquilibrage gravité du monde Outer Wilds

### DIFF
--- a/assets/worlds/3_outerwilds.json
+++ b/assets/worlds/3_outerwilds.json
@@ -14,7 +14,7 @@
       },
       {
         "name": "Sablière Rouge",
-        "mass": 100000000000,
+        "mass": 10000000000,
         "radius": 150,
         "color": "#FF8C00",
         "parentName": "Grand Feu",
@@ -24,7 +24,7 @@
       },
       {
         "name": "Sablière Noire",
-        "mass": 90000000000,
+        "mass": 9000000000,
         "radius": 140,
         "color": "#3B3B3B",
         "parentName": "Sablière Rouge",
@@ -44,7 +44,7 @@
       },
       {
         "name": "La Rocaille",
-        "mass": 10000000000,
+        "mass": 1500000000,
         "radius": 50,
         "color": "#CCCCCC",
         "parentName": "Âtrebois",
@@ -54,7 +54,7 @@
       },
       {
         "name": "Cravité",
-        "mass": 400000000000,
+        "mass": 30000000000,
         "radius": 280,
         "color": "#483D8B",
         "parentName": "Grand Feu",
@@ -64,7 +64,7 @@
       },
       {
         "name": "La Lanterne",
-        "mass": 5000000000,
+        "mass": 2000000000,
         "radius": 60,
         "color": "#FF4500",
         "parentName": "Cravité",
@@ -74,7 +74,7 @@
       },
       {
         "name": "Léviathe",
-        "mass": 900000000000,
+        "mass": 130000000000,
         "radius": 600,
         "color": "#20B2AA",
         "parentName": "Grand Feu",
@@ -84,7 +84,7 @@
       },
       {
         "name": "Sombronces",
-        "mass": 300000000000,
+        "mass": 25000000000,
         "radius": 250,
         "color": "#C0C0C0",
         "parentName": "Grand Feu",
@@ -114,7 +114,7 @@
       },
       {
         "name": "Lune quantique",
-        "mass": 10000000000,
+        "mass": 1500000000,
         "radius": 50,
         "color": "#AAAAAA",
         "parentName": "Grand Feu",
@@ -124,7 +124,7 @@
       },
       {
         "name": "L'Étranger",
-        "mass": 10000000000,
+        "mass": 4000000000,
         "radius": 100,
         "color": "#4B5320",
         "parentName": "Grand Feu",
@@ -134,7 +134,7 @@
       },
       {
         "name": "L'Œil de l'Univers",
-        "mass": 20000000000,
+        "mass": 4500000000,
         "radius": 100,
         "color": "#800080",
         "parentName": "Grand Feu",

--- a/assets/worlds/3_outerwilds.json
+++ b/assets/worlds/3_outerwilds.json
@@ -34,7 +34,7 @@
       },
       {
         "name": "Âtrebois",
-        "mass": 200000000000,
+        "mass": 30000000000,
         "radius": 300,
         "color": "#228B22",
         "parentName": "Grand Feu",

--- a/controllers/PhysicsController.js
+++ b/controllers/PhysicsController.js
@@ -183,8 +183,19 @@ class PhysicsController {
             if (celestialInfo.model.parentBody) {
                 // Mettre à jour la position du corps physique Matter.js
                 this.Body.setPosition(celestialInfo.body, celestialInfo.model.position);
-                // Mettre à jour la vélocité du corps physique Matter.js (calculée dans updateOrbit)
-                this.Body.setVelocity(celestialInfo.body, celestialInfo.model.velocity);
+                // Mettre à jour la vélocité du corps physique Matter.js (calculée dans updateOrbit).
+                // CORRECTION UNITÉS (cf. commit 96b471b, oublié ici) : model.velocity est en
+                // unités/SECONDE (orbitSpeed × orbitDistance). Matter.js attend une vélocité
+                // PAR PAS de simulation (= déplacement par tick ≈ valeur/seconde × deltaTime).
+                // Sans la conversion ×lastDeltaTime, un corps mobile comme Âtrebois (~72 u/s)
+                // voyait son body.velocity fixé à ~72/pas (≈60× trop). Au décollage, lorsque la
+                // fusée n'est plus épinglée mais encore en contact avec la surface, le solveur de
+                // collision de Matter.js applique alors cette vélocité tangentielle énorme à la
+                // fusée (friction), la catapultant latéralement à une vitesse anormale (~4320 u/s).
+                this.Body.setVelocity(celestialInfo.body, {
+                    x: (celestialInfo.model.velocity.x || 0) * this.lastDeltaTime,
+                    y: (celestialInfo.model.velocity.y || 0) * this.lastDeltaTime
+                });
                 // Assurer que le corps ne s'endort pas
                 celestialInfo.body.isSleeping = false;
             }


### PR DESCRIPTION
## Problème
Au décollage depuis **Âtrebois** (monde Outer Wilds), la fusée soit **restait collée** au sol, soit était **éjectée latéralement à une vitesse anormale**.

## Cause racine (deux bugs indépendants)
Âtrebois est le seul lieu de spawn à la fois **mobile** (en orbite) et à **gravité de surface anormale** :

1. **Collage — gravité > poussée.** Âtrebois avait la masse de la Terre (`2e11`) pour un rayon 2,4× plus petit (300 vs 720) → gravité de surface ~5,8× celle de la Terre. Avec le G réel du plugin matter-attractors (`0,001`, jamais surchargé), la poussée max (825 k) ne valait que **30 %** de la gravité au sol → décollage physiquement impossible.
2. **Éjection anormale — catapulte tangentielle.** Le commit `96b471b` avait converti la vélocité orbitale u/s → par-pas (`×deltaTime`) partout sauf `PhysicsController.js:187`, où `body.velocity` d'Âtrebois (~72 u/s) était fixée à 72 **par-pas** (~60× trop). Au contact lors du décollage, le solveur de collision projetait cette vélocité tangentielle sur la fusée → catapulte (~4320 u/s).

## Corrections
- **`PhysicsController.js`** : conversion `×lastDeltaTime` de la vélocité physique des corps mobiles (complète le fix d'unités du commit `96b471b`). Bénéficie à *tous* les mondes (Lune, Phobos, Deimos…). Aucun effet de bord : les lecteurs du jeu lisent `model.velocity`.
- **`assets/worlds/3_outerwilds.json`** : rééquilibrage des masses pour amener chaque corps **atterrissable** dans une bande jouable (ratio poussée/gravité **~1,5–3**), différences relatives préservées (Léviathe la plus lourde à 1,68 ; petites lunes ~2,35). Les orbites étant cinématiques, les masses n'affectent que la gravité ressentie par la fusée.
  - Exceptions volontaires : *Grand Feu* (étoile) gardé lourd (ancre la gravité interplanétaire, pas une cible d'atterrissage) ; *Trou blanc* / *L'Intrus* (exotiques minuscules) déjà décollables, laissés tels quels.

## Validation
Vérifié par **calcul des forces** (projet navigateur sans tests automatisés) : avant, 10 des 13 corps avaient un ratio poussée/gravité < 1 (impossibles à quitter) ; après, tous les corps atterrissables sont décollables. Âtrebois : 0,30 → 2,00.

## Note (latent, hors périmètre)
Le `G` réel de la gravité est celui du plugin (`0,001`), jamais surchargé → le `physics.G: 0.0001` des presets n'agit que sur la visualisation/IA, pas sur la gravité réelle.

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_