### PR TITLE
Décollage corps mobile : hériter correctement de la vélocité orbitale

### DIFF
--- a/controllers/ThrusterPhysics.js
+++ b/controllers/ThrusterPhysics.js
@@ -172,16 +172,24 @@ class ThrusterPhysics {
                 cb => cb.model && cb.model.name === landedOnBodyName
             );
             if (celestialBodyInfo && celestialBodyInfo.model && celestialBodyInfo.model.velocity) {
-                // model.velocity est en unités/seconde (vélocité orbitale du corps). La vélocité
-                // d'un corps Matter.js (rocketBody) est un déplacement PAR PAS de simulation. On
-                // convertit donc (× deltaTime), sinon la fusée hériterait d'une vitesse ~60× trop
-                // grande et le décollage ne serait pas relatif à la planète.
-                const dt = (this.physicsController && this.physicsController.lastDeltaTime) || (1 / 60);
+                // model.velocity est en unités/SECONDE (vélocité orbitale du corps). La fusée doit
+                // hériter de ce mouvement pour décoller "avec" la planète (rester relative à elle).
+                //
+                // SUBTILITÉ MATTER.JS (vérifiée empiriquement par repro headless) : le jeu passe
+                // deltaTime en SECONDES à Engine.update, alors que Matter suppose des millisecondes
+                // (_baseDelta = 1000/60). Conséquence : la `velocity` d'un corps Matter vaut
+                // (déplacement réel par pas) × (1000/60). Pour qu'au décollage la fusée se déplace
+                // EXACTEMENT comme le corps (model.velocity × dt par pas), il faut donc régler sa
+                // vélocité Matter à model.velocity × (1000/60) — le dt se simplifie, le facteur est
+                // constant. L'ancienne conversion × deltaTime (≈ ×0.0167) était ~1000× trop petite :
+                // la fusée n'héritait quasiment pas de l'orbite et "glissait" en arrière du corps
+                // mobile (dérive tangentielle ~2× celle d'un corps statique). Avec ce facteur, la
+                // dérive orbitale est annulée (décollage propre, comme sur un corps immobile).
+                const MATTER_BASE_DELTA = 1000 / 60; // _baseDelta interne de Matter.js (ms)
                 inheritedVelocity = {
-                    x: (celestialBodyInfo.model.velocity.x || 0) * dt,
-                    y: (celestialBodyInfo.model.velocity.y || 0) * dt
+                    x: (celestialBodyInfo.model.velocity.x || 0) * MATTER_BASE_DELTA,
+                    y: (celestialBodyInfo.model.velocity.y || 0) * MATTER_BASE_DELTA
                 };
-                console.log(`[LIFTOFF] Vélocité héritée de ${landedOnBodyName} (par pas): (${inheritedVelocity.x.toFixed(3)}, ${inheritedVelocity.y.toFixed(3)})`);
             }
         }
 


### PR DESCRIPTION
## Problème
Au décollage depuis un corps **en orbite** (ex: Âtrebois), la fusée « glissait » en arrière du corps (dérive tangentielle ~2× celle d'un corps immobile) : elle n'héritait quasiment pas de la vélocité orbitale. C'est le résiduel « pas parfait » du décollage sur corps mobile.

## Cause racine (prouvée par repro headless avec le vrai Matter.js)
Le jeu passe `deltaTime` en **secondes** à `Engine.update`, alors que Matter.js suppose des **millisecondes** (`_baseDelta = 1000/60`). Conséquence : la `velocity` d'un corps Matter vaut `(déplacement réel par pas) × (1000/60)`. La conversion `× deltaTime` de la vélocité héritée (commit `96b471b`) était donc **~1000× trop petite** → quasi aucun héritage orbital.

## Correctif
`ThrusterPhysics.handleLiftoff` : vélocité héritée = `model.velocity × (1000/60)` au lieu de `× deltaTime` (le `dt` se simplifie ; facteur constant qui fait co-mouvoir exactement la fusée avec le corps).
- **No-op pour les corps immobiles** (vélocité 0) → aucune régression.
- Améliore aussi le décollage depuis toutes les lunes en orbite (Lune, Phobos, Io, etc.).

## Vérification empirique (repro headless, Âtrebois orbitant à 72 u/s, vrai code + vrai Matter.js)
| | dérive tangentielle au décollage | excès vs corps statique |
|---|---|---|
| Avant (`× dt`) | −6,64° | −3,57° ❌ |
| **Après (`× 1000/60`)** | **−2,65°** | **+0,42°** ✅ |

→ Âtrebois décolle désormais aussi proprement qu'un corps immobile (dérive orbitale annulée).

## Note (hors périmètre)
La même bévue secondes-vs-ms affecte d'autres conversions `model.velocity → Matter` (détection de crash relatif, stabilisation au sol). Non touchées ici (elles influencent l'atterrissage/crash, calibré et fonctionnel) — nettoyage de fond possible ultérieurement.

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_