### PR TITLE
Docs : 4 documents complémentaires (CLAUDE/PHYSICS/CHANGELOG/TODO) décrivant le code réel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,95 @@
+# CHANGELOG — Pocket Cosmos
+
+Historique des changements notables. Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/),
+ordre antéchronologique. Le dépôt n'a **pas de tags de version** ; les sections sont donc datées.
+Voir aussi [PHYSICS.md](PHYSICS.md) (détails techniques), [TODO.md](TODO.md) (dettes/à faire) et
+[CLAUDE.md](CLAUDE.md) (architecture).
+
+---
+
+## [Non publié] — Corrections du décollage (corps mobiles) — 2026‑06‑04
+
+### Corrigé
+- **Décollage propre depuis un corps en orbite** (`ThrusterPhysics.handleLiftoff`) — `35352c8`.
+  La vélocité orbitale héritée passe de `× deltaTime` (~0,0167, soit ~1000× trop petit) à
+  `× (1000/60)` (`MATTER_BASE_DELTA`). Cause : le jeu passe `deltaTime` en **secondes** à
+  `Engine.update` alors que Matter suppose des **ms** (`_baseDelta = 1000/60`). Vérifié en headless
+  (vrai Matter.js) : dérive tangentielle au décollage **−6,64° → −2,65°** (niveau d'un corps fixe).
+  No‑op pour les corps immobiles → aucune régression ; améliore aussi le décollage des lunes en orbite.
+- **Catapulte tangentielle au décollage** (`PhysicsController.update`, étape 1) — `0851b0b`.
+  La vélocité Matter des corps mobiles est convertie en par‑pas (`× lastDeltaTime`) ; complète le
+  fix d'unités `96b471b` qui avait oublié cette ligne.
+
+### Modifié
+- **Rééquilibrage des masses du monde Outer Wilds** (`assets/worlds/3_outerwilds.json`) — `145e3bb`,
+  `0851b0b`. Âtrebois `2e11 → 3e10` (à `2e11`, gravité 3,3× la poussée → décollage impossible).
+  10 des 13 corps avaient un rapport poussée/gravité < 1 ; masses ré‑échelonnées pour viser ~1,5–3
+  en préservant les écarts relatifs. *Grand Feu* (étoile) gardé lourd (ancre la gravité
+  interplanétaire) ; *Trou blanc*/*L'Intrus* (exotiques) laissés tels quels. Orbites inchangées
+  (cinématiques).
+
+### Connu / non corrigé (voir [TODO.md](TODO.md))
+- Incohérence d'unités secondes↔ms encore présente dans la stabilisation au sol, la détection de
+  crash relatif (`getCelestialBodyVelocity`) et la vélocité de collision des corps célestes.
+- `gravityConstant` du plugin (0,001) ≠ `PHYSICS.G` (0,0001) : le champ de gravité affiché et les
+  calculs IA sont ~10× sous la gravité réelle.
+
+---
+
+## 2026‑06‑02 — Stabilisation décollage & atterrissage relatif
+
+### Corrigé
+- `6d9c88e` — Re‑collage de la fusée sur les corps mobiles au décollage : machine à états de la
+  période de grâce (empêche `isLanded` d'être ré‑armé pendant la montée) + diagnostic
+  `window.DEBUG_LIFTOFF`.
+- `e3f4246` — Direction de l'impulsion de décollage : pousse vers l'extérieur (`angle - π/2`) et non
+  vers le centre de la planète.
+- `96b471b` — Incohérence d'unités : conversion de la vélocité des corps célestes (u/s → par‑pas
+  Matter via `× deltaTime`) dans `handleLiftoff`, la stabilisation et `getCelestialBodyVelocity`.
+- `0e9546e` — Détection atterrissage/crash basée sur la vitesse **relative** au corps céleste.
+
+### Notes
+- Correctifs IA/entraînement, particules et rendu groupés (`c97977c`, `0421d97`, série de bugfixes).
+
+---
+
+## Antérieur — par thème
+
+> Résumé thématique des évolutions structurantes (avant la campagne décollage). Voir `git log` pour
+> le détail commit par commit.
+
+### Système d'univers & écran de démarrage
+- Écran de démarrage avec sélection parmi 6 mondes (`1_solar`, `2_kerbol`, `3_outerwilds`, `4_Tatoo`,
+  `5_Endor`, `6_alien`) et bouton « Prêt ! » ; émission de `UNIVERSE_LOAD_REQUESTED`.
+- Chargement de monde par preset JSON (`GameSetupController.buildWorldFromData`) : corps, stations,
+  étoiles, ceintures d'astéroïdes, récits, spawn fusée. Génération procédurale & rechargement
+  d'univers modulaires.
+- Nouveaux corps (Cérès, Pluton), ceintures d'astéroïdes, atmosphères (ombres, couches avant/arrière),
+  anneaux planétaires.
+
+### IA (Deep Q‑Network, TensorFlow.js)
+- Agent `RocketAI`, `TrainingOrchestrator`, environnement headless `HeadlessRocketEnvironment`,
+  visualiseur `TrainingVisualizer`. Objectifs : `navigate` (défaut), `orbit`, `land`, `crash`.
+- Système de récompenses `navigate` (6 composantes) ; constantes `AI_TRAINING` ; nettoyages mémoire
+  (tenseurs `tf.tidy`/`dispose`) ; repli backend CPU si WebGL échoue.
+
+### Audio
+- `AudioManager` : préchargement et lecture des SFX (propulseur, collision) et ambiances ; déverrouillage
+  audio au premier clic/touche.
+
+### Rendu
+- Pipeline `RenderingController` : fond/étoiles, corps célestes (ombres jour/nuit, atmosphère, anneaux),
+  stations, traces, particules, fusée, vecteurs/champ de gravité, HUD.
+
+### Refactors & robustesse
+- Découplage via `EventBus` ; `ControllerContainer.track` pour le nettoyage des abonnements (anti‑fuite
+  au rechargement d'univers) ; centralisation de la consommation de carburant dans `RocketModel`.
+
+---
+
+## Conventions de mise à jour de ce fichier
+
+- À chaque changement notable, ajouter une entrée sous **[Non publié]** (catégories : *Ajouté*,
+  *Modifié*, *Corrigé*, *Supprimé*, *Connu/non corrigé*) avec le hash de commit court.
+- Tout changement **physique** doit référencer la section concernée de [PHYSICS.md](PHYSICS.md) et
+  idéalement être vérifié par le harnais headless (vrai Matter.js).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Pocket Cosmos is an interactive 2D rocket simulation with realistic physics using Matter.js. It features a mission system, cargo management, optional AI (TensorFlow.js), and procedural universe generation. The project uses a modular MVC-extended architecture with an EventBus for decoupled communication.
 
+## Documentation Map
+
+These four docs are complementary — keep them in sync when you change the code:
+
+| File | Purpose |
+|------|---------|
+| **CLAUDE.md** (this file) | Architecture, conventions, how to work in the repo — start here |
+| **[PHYSICS.md](PHYSICS.md)** | Precise physics/simulation reference (units, gravity, forces, collision, takeoff). **Read before touching physics.** |
+| **[CHANGELOG.md](CHANGELOG.md)** | Reverse-chronological history of notable changes |
+| **[TODO.md](TODO.md)** | Known issues & tech debt (esp. unit/gravity inconsistencies) and roadmap |
+
 ## Running the Project
 
 This is a browser-based application with no build step:
@@ -70,18 +81,20 @@ The EventBus is the heart of inter-module communication:
 3. `RocketController` updates `RocketModel`
 4. `ThrusterPhysics` applies force to Matter.js body
 
-**Game Loop** (60 FPS):
-1. `gameController.update()` called
-2. `physicsController.update()` advances Matter.js
-3. `synchronizationManager.sync()` updates models from physics
-4. Other controllers update their logic
-5. `renderingController.render()` draws current state
+**Game Loop** (~60 FPS via `requestAnimationFrame`; `deltaTime` in **seconds**, capped at 0.05):
+1. `inputController.update()`
+2. `universeModel.update(deltaTime)` — advances the kinematic orbits
+3. `physicsController.update(deltaTime)` — orbits sync → landed-rocket pinning → thrusters → `Engine.update` (gravity + collisions) → model sync → periodic landing check
+4. `rocketController.update()`, `rocketAI.update()` (if active), `particleController.update()`, `rocketModel.update()` (fuel), `cameraModel.update()`, `missionManager.update()`
+5. `renderingController.render()` draws the current state
+
+> `SynchronizationManager` has **no** `sync()` entry point: it hooks Matter's `beforeUpdate`/`afterUpdate` events and syncs **bidirectionally** (physics→model in flight; model→physics when landed/attached, to pin the rocket to a surface). See [PHYSICS.md §4](PHYSICS.md).
 
 **Collision Handling**:
 1. Matter.js detects collision
 2. `CollisionHandler` analyzes impact (speed, angle, angular velocity) against thresholds in `constants.js`
-3. Updates `rocketModel.isLanded` or `rocketModel.isCrashed`, recalculates relative position on landing
-4. `SynchronizationManager` creates physical constraint to "attach" rocket
+3. Updates `rocketModel.isLanded` or `rocketModel.isDestroyed`, recalculates relative position on landing
+4. `SynchronizationManager` force-syncs the rocket's position/velocity to "attach" it to the body (no Matter constraint is created)
 5. Landing triggers `MISSION_COMPLETED` check via `MissionManager`
 
 ## Universe System (Presets & Procedural)
@@ -109,12 +122,16 @@ JSON files in `assets/worlds/` can define:
 
 ## Physics & Matter.js
 
-- **Engine**: Matter.js 0.19.0 with matter-attractors plugin
-- **Gravity**: Applied by matter-attractors plugin during physics update
-- **Collision categories**: Defined in `PHYSICS.COLLISION_CATEGORIES` to control what collides
-- **Thresholds**: Landing/crash/liftoff speeds in `constants.js`
+- **Engine**: Matter.js 0.19.0 with the matter-attractors plugin
+- **Gravity**: Applied by the matter-attractors plugin during `Engine.update`. ⚠️ The plugin's `gravityConstant` is **0.001** (its default, never overridden in the code) — that is the REAL gravity. `PHYSICS.G` (0.0001 in `constants.js`, overridable per preset) feeds ONLY the debug/visualization and AI gravity calculations, **NOT** the actual forces.
+- **Units pitfall**: the game passes `deltaTime` in **seconds** to `Engine.update`, while Matter assumes **milliseconds** (`_baseDelta = 1000/60`). Consequence: a body's `velocity` ≈ (units/second) × (1000/60). This is the root of most physics subtleties.
+- **Orbits are kinematic**: celestial bodies follow a prescribed `orbitSpeed` (not gravity), so a body's mass only affects the gravity felt by the rocket — never the bodies' own trajectories.
+- **Collision categories**: Defined in `PHYSICS.COLLISION_CATEGORIES`
+- **Thresholds**: Landing/crash/liftoff in `constants.js`
 
-**Important**: Manual gravity calculations (like `calculateGravityAccelerationAt`) are for visualization/debug only, NOT for applying forces.
+**Important**: Manual gravity calculations (`calculateGravityAccelerationAt`, etc.) are for visualization/debug/AI only, NOT for applying forces.
+
+👉 **Precise physics reference (units, forces, takeoff, collision, sync, constants): [PHYSICS.md](PHYSICS.md). Read it before changing physics.**
 
 ## Constants & Configuration
 
@@ -134,10 +151,15 @@ World-specific data (body masses, positions) should come from preset JSON files,
 
 **Rendering pipeline** (in `RenderingController.render()`):
 1. Clear canvas
-2. `universeView.render()`: Background, stars, celestial bodies
-3. `rocketView.render()`: Rocket with thrusters
-4. Conditional views: `traceView`, `vectorsView`, `gravityFieldView`
-5. `uiView.render()`: UI overlays
+2. `universeView.render()`: Background, stars, celestial bodies, asteroid belts
+3. `stationView.render()`: Station icons/labels anchored to bodies
+4. `traceView.render()`: Trajectory trail
+5. `particleView`: Thrust/explosion particles
+6. `rocketView.render()`: Rocket with thrusters
+7. Conditional: `vectorsView` (force vectors and/or gravity field arrows/equipotentials)
+8. `uiView.render()`: HUD and modal screens
+
+(When paused, only `uiView.render()` runs.)
 
 **Visual features**:
 - Day/night shadowing on planets oriented by central star
@@ -171,7 +193,7 @@ The AI uses Deep Q-Network (DQN) with TensorFlow.js:
 
 **Other reward configs** (`AI_TRAINING` in `constants.js`):
 - `REWARDS`: Standard reward values for orbit, landing, and penalties
-- `ORBIT`: Calculated orbital parameters consistent with physics (G=0.0001)
+- `ORBIT`: Orbital parameters for the `orbit` objective. ⚠️ Computed with G=0.0001, but the REAL gravity uses G=0.001 (see [PHYSICS.md](PHYSICS.md)) — a known inconsistency (see [TODO.md](TODO.md))
 
 **Training methods**:
 1. Web interface: `training-interface.html` (recommended) - Full application with configuration, real-time performance charts, metrics, and trajectory visualization

--- a/PHYSICS.md
+++ b/PHYSICS.md
@@ -1,0 +1,260 @@
+# PHYSICS.md — Référence physique de Pocket Cosmos
+
+> Référence **précise** du moteur de simulation réel (Matter.js 0.19 + matter‑attractors 0.1.6).
+> Destinée aux IA/développeurs qui modifient la physique. Pour l'architecture globale voir
+> [CLAUDE.md](CLAUDE.md) ; pour les dettes/incohérences connues voir [TODO.md](TODO.md) ;
+> pour l'historique voir [CHANGELOG.md](CHANGELOG.md).
+
+⚠️ **Avant de toucher à la physique, lisez la section 1 (unités/temps). C'est la source de 90 % des pièges du projet.**
+
+---
+
+## 0. Le modèle en une phrase
+
+La gravité est appliquée par le plugin **matter‑attractors** (loi en 1/r²). Les corps célestes
+sont **statiques** et **cinématiques** (leur orbite est imposée par `orbitSpeed`, PAS calculée par
+la gravité). Seule la fusée est un corps dynamique réellement intégré par Matter.js. La fusée est
+attirée par tous les corps ; les corps ne s'attirent pas entre eux.
+
+---
+
+## 1. Unités & temps — LE piège central
+
+### 1.1 deltaTime est en SECONDES, mais Matter.js suppose des millisecondes
+
+- `GameController.gameLoop` calcule `deltaTime = (timestamp - lastTimestamp) / 1000` → **secondes**
+  (borné à `[0, 0.05]`). À 60 FPS, `deltaTime ≈ 0.0167`.
+- `PhysicsController.update(deltaTime)` mémorise `this.lastDeltaTime = deltaTime` puis appelle
+  `Engine.update(engine, deltaTime * timeScale)` — il passe donc à Matter un delta **en secondes**.
+- Or Matter.js suppose des **millisecondes** : sa constante interne `_baseDelta = 1000/60 ≈ 16.667`.
+
+### 1.2 Conséquence : `body.velocity` de Matter n'est PAS le déplacement par pas
+
+Matter calcule `body.velocity = (position - positionPrev) × (_baseDelta / delta)`.
+Avec `delta = 1/60` et `_baseDelta = 1000/60`, le facteur vaut **1000**.
+
+| Grandeur | Relation (à 60 FPS) |
+|---|---|
+| Déplacement réel par pas `D` | `D = body.velocity × (delta/_baseDelta) = body.velocity × 0.001` |
+| `body.velocity` rapportée | `= D × 1000` |
+| `body.velocity` en fonction de la vitesse réelle `v` (unités/seconde) | `body.velocity = v × (1000/60) ≈ v × 16.667` |
+
+> **Vérifié empiriquement** (harnais headless avec le vrai Matter.js) : une force de 825 000 sur une
+> masse de 1500 donne, à `delta=1/60`, `body.velocity ≈ 152.8` mais un déplacement réel de `0.1528`
+> par pas (rapport 1000). Voir CHANGELOG (fix `35352c8`).
+
+### 1.3 Convertir une vitesse modèle (u/s) en vitesse Matter
+
+`model.velocity` des corps célestes est en **unités/seconde** (orbital ; voir §5).
+Pour qu'un corps Matter se déplace **comme** un corps cinématique se déplaçant à `model.velocity` :
+
+```
+velocityMatter = model.velocity × (1000/60)
+```
+
+Le `dt` se **simplifie** (le mouvement réel du corps ∝ dt, et le scaling Matter ∝ 1/dt) → le facteur
+est **constant = `_baseDelta = 1000/60`**, indépendant du FPS.
+
+### 1.4 Où cette conversion est faite (et son exactitude)
+
+| Endroit | Facteur actuel | Facteur correct | État |
+|---|---|---|---|
+| `ThrusterPhysics.handleLiftoff` (vélocité héritée au décollage) | **`× 1000/60`** | `× 1000/60` | ✅ correct (fix `35352c8`) |
+| `PhysicsController.update` étape 1 (vélocité Matter du corps céleste, pour le solveur de collision) | `× lastDeltaTime` | `× 1000/60` | ⚠️ ~1000× trop petit (sûr : évite la catapulte, mais le corps paraît ~immobile au solveur) |
+| `SynchronizationManager` stabilisation au sol (`parentVelocity`) | `× lastDeltaTime` | `× 1000/60` | ⚠️ ~1000× trop petit (masqué : la position est forcée quand on est posé) |
+| `CollisionHandler.getCelestialBodyVelocity` (vitesse relative pour atterrissage/crash) | `× lastDeltaTime` | `× 1000/60` | ⚠️ ~1000× trop petit → la détection est **de fait ABSOLUE** sur les corps mobiles, pas relative |
+
+> Ces 3 lignes ⚠️ sont des **incohérences connues** : elles « marchent » par effet de bord mais sont
+> en mauvaises unités. Ne pas les « corriger » à l'aveugle (cela change l'atterrissage/crash et la
+> détection de collision sur les corps mobiles — tester). Voir [TODO.md](TODO.md).
+
+---
+
+## 2. Gravité
+
+### 2.1 La gravité réelle utilise G = 0,001 (pas `PHYSICS.G`)
+
+- La gravité est fournie par `MatterAttractors.Attractors.gravity`, attaché à la fusée **et** à
+  chaque corps céleste dans `BodyFactory` (`plugin.attractors`).
+- Formule du plugin : `magnitude = -gravityConstant × (massA × massB) / distanceSq`.
+- `gravityConstant` du plugin = **0,001** par défaut, et **rien dans le projet ne le surcharge**
+  (vérifié : aucun set de `MatterAttractors.Attractors.gravityConstant`). → **La gravité réelle
+  utilise 0,001.**
+
+### 2.2 `PHYSICS.G = 0.0001` est une valeur de VISUALISATION uniquement
+
+- `PHYSICS.G` (constants.js) et la `gravitationalConstant` de `PhysicsController` ne servent qu'aux
+  calculs de **debug/visualisation/IA** : `calculateGravityForceForDebug`, `calculateGravityAtPoint`,
+  `calculateGravityAccelerationAt` (champ de gravité affiché, vecteurs, état pour l'IA).
+- Un preset JSON peut faire `PHYSICS.G = data.physics.G` (`GameSetupController`), mais cela
+  **n'affecte QUE la visualisation/IA**, **pas** la gravité réelle du plugin.
+- ⇒ Le champ de gravité dessiné (G=0,0001) est ~**10× plus faible** que la gravité réellement subie
+  (G=0,001). Incohérence connue (voir [TODO.md](TODO.md)).
+
+### 2.3 Décollabilité = rapport poussée/gravité (indépendant des unités)
+
+Accélération de poussée (plein régime principal) = `825000 / 1500 = 550`.
+Accélération de gravité de surface = `G_plugin × M_corps / d²` (avec `d ≈ rayon + HEIGHT/2`).
+
+| Corps | masse | rayon | a_gravité | poussée/gravité | décolle ? |
+|---|---|---|---|---|---|
+| Terre (`1_solar`) | 2e11 | 720 | ≈ 356 | **1,55** | ✅ |
+| Âtrebois **avant** | 2e11 | 300 | ≈ 1836 | **0,30** | ❌ (impossible) |
+| Âtrebois **après** (`3e10`) | 3e10 | 300 | ≈ 275 | **2,0** | ✅ |
+
+> Règle de design : pour qu'un corps soit décollable, **poussée/gravité > 1** (viser ~1,5–3).
+> Comme G_plugin = 0,001, des masses « réalistes » (2e11) avec petits rayons rendent le décollage
+> impossible. Les masses des presets doivent être tunées pour ce G.
+
+### 2.4 Les orbites sont CINÉMATIQUES
+
+`CelestialBodyModel.updateOrbit(dt)` impose l'orbite (pas de gravité entre corps) :
+```
+currentOrbitAngle += orbitSpeed × dt           // orbitSpeed en rad/seconde
+position = parent.position + (cos, sin)(currentOrbitAngle) × orbitDistance
+velocity = ω×r perpendiculaire + parent.velocity   // tangentSpeed = orbitSpeed × orbitDistance  (u/s)
+```
+⇒ **La masse d'un corps n'influe QUE sur la gravité ressentie par la fusée**, jamais sur les
+trajectoires des corps. On peut donc rééquilibrer les masses sans casser les orbites.
+
+---
+
+## 3. Poussée & propulsion (`ThrusterPhysics`)
+
+### 3.1 Force d'un propulseur
+
+`powerRatio = clamp(power / maxPower, 0, 1)`. Force appliquée via `Body.applyForce` au **point du
+propulseur** (bras de levier `THRUSTER_POSITIONS`, tourné par l'angle fusée) :
+
+| Propulseur | Formule | Force max (plein régime) |
+|---|---|---|
+| `main` | `MAIN_THRUST × ratio × EFFECTIVENESS.MAIN × THRUST_MULTIPLIER` | `5500 × 1.5 × 100 = 825 000` |
+| `rear` | `REAR_THRUST × ratio × EFFECTIVENESS.REAR × THRUST_MULTIPLIER` | `3000 × 1.5 × 100 = 450 000` |
+| `left`/`right` | `(LATERAL_THRUST × ratio × EFFECTIVENESS.LATERAL × THRUST_MULTIPLIER) / 2` | `(100 × 0.3 × 100)/2 = 1 500` chacun |
+
+- `power` est une **valeur absolue** (0..maxPower), pas un pourcentage. Utiliser `power/maxPower`.
+- `main`/`rear` poussent selon l'axe fusée ; `left`/`right` perpendiculairement (contrôle de rotation).
+- Si `fuel <= 0` → force nulle. La **consommation** est gérée uniquement dans `RocketModel.update`
+  (`power × FUEL_CONSUMPTION[type] × dt`), pour éviter la double‑décrémentation.
+
+### 3.2 Décollage (`handleLiftoff`)
+
+Appelé quand `main` est actif et la fusée posée. Une seule fois par décollage (ensuite `isLanded=false`).
+1. Récupère la vélocité héritée du corps quitté : `model.velocity × (1000/60)` (co‑mouvement, §1.3).
+2. `isLanded=false`, `landedOn=null`, `relativePosition=null`, `startLiftoffGracePeriod(500)`.
+3. Impulsion `applyForce` de 50 vers l'extérieur (`angle - π/2`).
+4. `setVelocity = 20 (vers l'extérieur) + vélocité héritée`.
+
+---
+
+## 4. Boucle physique & synchronisation
+
+### 4.1 `PhysicsController.update(deltaTime)` — ordre exact
+
+1. **Corps célestes** : pour chaque corps mobile (`parentBody != null`) → `setPosition(model.position)`
+   et `setVelocity(model.velocity × lastDeltaTime)` (cf. §1.4 ⚠️), `isSleeping=false`.
+2. `synchronizationManager.handleLandedOrAttachedRocket` (épingle la fusée posée/attachée — §4.3).
+3. `thrusterPhysics.applyRotationStabilization` (amortit la rotation si contrôles assistés).
+4. `thrusterPhysics.updateThrusters` (applique les forces des propulseurs).
+5. **`Engine.update(engine, deltaTime)`** → gravité (plugin), collisions, intégration. **C'est ici
+   que la gravité réelle (G=0,001) agit.**
+6. `synchronizationManager.syncModelWithPhysics` **sauf** si `isHandledManually` (posé/attaché sur
+   un corps mobile, ou posé sur 'Terre').
+7. `checkRocketLandedStatusPeriodically` (~toutes les 150 ms).
+
+### 4.2 Crochets Matter (enregistrés par `SynchronizationManager`)
+
+`SynchronizationManager` n'est **pas** appelé directement comme « sync() » : il s'abonne aux
+événements du moteur :
+- `beforeUpdate` : `syncMovingBodyPositions()` + (si posé/détruit **et** pas en grâce **et** pas de
+  poussée) `handleLandedOrAttachedRocket` + `syncPhysicsWithModel` (modèle → physique).
+- `afterUpdate` : `syncModelWithPhysics` (physique → modèle).
+
+> La synchro est donc **bidirectionnelle** : `physique → modèle` en vol (`afterUpdate`), mais
+> `modèle → physique` quand la fusée est posée/attachée (pour la coller à la surface).
+
+### 4.3 Fusée posée sur un corps mobile (épinglage)
+
+Quand `isLanded` sur un corps en orbite, `handleLandedOrAttachedRocket` :
+- calcule/maintient `relativePosition` (offset polaire vs centre du corps + angle orbital de référence) ;
+- chaque frame : `updateAbsolutePosition` recalcule la position depuis l'orbite courante du corps,
+  `setPosition` force la fusée dessus, angle perpendiculaire forcé, vélocité = vélocité parent, ω=0.
+- **Garde décollage** : si `main > TAKEOFF_THRUST_THRESHOLD_PERCENT` (10 %), retourne **immédiatement**
+  (pas d'épinglage) et déclenche/rafraîchit la grâce → la fusée n'est jamais re‑collée pendant la poussée.
+
+---
+
+## 5. Machine à états atterrissage / crash / décollage (`CollisionHandler`)
+
+### 5.1 `isRocketLanded`
+
+- **Délai de collision** : aucune collision pendant `COLLISION_DELAY = 2000 ms` après init.
+- **Grâce de décollage** : si `isInLiftoffGracePeriod()` → renvoie `false` (jamais posé).
+- **Proximité** : `|distance - rayon - HEIGHT/2| < 15 px`.
+- **Vitesse relative** au corps (via `getCelestialBodyVelocity`, cf. §1.4 ⚠️ : de fait ~absolue sur
+  corps mobiles).
+- **CRASH** si proche & collisions actives & au moins un de :
+  `vitesse ≥ CRASH_SPEED_THRESHOLD (2500)` · `|Δangle| ≥ CRASH_ANGLE_DEG (45°)` ·
+  `|ω| ≥ CRASH_ANGULAR_VELOCITY (400)` → `isDestroyed=true`, dégâts fatals, enfoncement visuel.
+- **ATTERRISSAGE STABLE** si proche & **toutes** :
+  `vitesse < LANDING_MAX_SPEED (2500)` · `|Δangle| ≤ LANDING_MAX_ANGLE_DEG (30°)` ·
+  `|ω| ≤ LANDING_MAX_ANGULAR_VELOCITY (400)`.
+
+> ⚠️ Les seuils sont en **unités Matter rapportées** (≈ u/s × 16,667). 2500 ↔ ~150 u/s. Les seuils
+> atterrissage et crash étant tous deux à 2500, l'angle/ω départagent les cas limites.
+
+### 5.2 Grâce de décollage (`RocketModel`)
+
+- `startLiftoffGracePeriod(500)` : pose `_liftoffGracePeriodEnd = Date.now() + 500`.
+- Rafraîchie **chaque frame** tant que `main > 10 %` (couvre tout le décollage + 500 ms après).
+- `isInLiftoffGracePeriod()` (lecture seule) ; `canSetLanded()` (renvoie false pendant la grâce, et
+  toujours false si `isDestroyed`).
+
+---
+
+## 6. Corps physiques (`BodyFactory`)
+
+| Propriété | Fusée | Corps céleste |
+|---|---|---|
+| type | `rectangle(WIDTH=30, HEIGHT=60)`, dynamique | `circle(radius)`, `isStatic: true` |
+| `mass` | `ROCKET.MASS = 1500` | `bodyModel.mass` (du JSON) |
+| `inertia` | `MASS × 1.5` | — |
+| `friction` | `0` | `0.05` |
+| `frictionAir` | `0.1` | — |
+| `restitution` | `0.05` | `PHYSICS.RESTITUTION = 0.2` |
+| `sleepThreshold` | `-1` (jamais endormi) | — |
+| `collisionFilter` | cat `ROCKET (0x0001)`, masque `0xFFFFFFFF` | cat `CELESTIAL (0x0002)`, masque `ROCKET` |
+| `plugin.attractors` | `[Attractors.gravity]` | `[Attractors.gravity]` |
+| `angularDamping` | dynamique (assisté : 2.0 / normal : 0.0) | — |
+
+---
+
+## 7. Référence des constantes (`constants.js`)
+
+**PHYSICS** : `G=0.0001` (viz) · `MAX_SPEED=10000` · `COLLISION_DELAY=2000` ·
+`IMPACT_DAMAGE_FACTOR=10` · `RESTITUTION=0.2` · `CRASH_SPEED_THRESHOLD=2500` ·
+`LANDING_MAX_SPEED=2500` · `LANDING_MAX_ANGLE_DEG=30` · `LANDING_MAX_ANGULAR_VELOCITY=400` ·
+`CRASH_ANGLE_DEG=45` · `CRASH_ANGULAR_VELOCITY=400` · `TAKEOFF_THRUST_THRESHOLD_PERCENT=10` ·
+`THRUST_MULTIPLIER=100` · `COLLISION_CATEGORIES{ROCKET:0x0001, CELESTIAL:0x0002}` ·
+`ASSISTED_CONTROLS{NORMAL_ANGULAR_DAMPING:0, ASSISTED_ANGULAR_DAMPING:2, ROTATION_STABILITY_FACTOR:0.05}`.
+
+**ROCKET** : `MASS=1500` · `WIDTH=30` · `HEIGHT=60` · `FRICTION=0` · `MAX_HEALTH=100` ·
+`FUEL_MAX=6000` · `FUEL_CONSUMPTION{MAIN:0.2, REAR:0.2, LATERAL:0.05}` · `MAIN_THRUST=5500` ·
+`LATERAL_THRUST=100` · `REAR_THRUST=3000` · `THRUSTER_POWER{MAIN:1000, REAR:200, LEFT:20, RIGHT:20}` ·
+`THRUSTER_EFFECTIVENESS{MAIN:1.5, REAR:1.5, LATERAL:0.3}` ·
+`THRUSTER_POSITIONS{MAIN:{-π/2,30}, REAR:{π/2,30}, LEFT:{π,15}, RIGHT:{0,15}}`.
+
+> ⚠️ « Note magique » : `MATTER_BASE_DELTA = 1000/60` est défini en dur dans `ThrusterPhysics`.
+> Candidat à centraliser dans `constants.js` (voir [TODO.md](TODO.md)).
+
+---
+
+## 8. Pièges récapitulatifs
+
+1. **Ne jamais raisonner « body.velocity = déplacement par pas ».** C'est `× 1000/60` la vitesse u/s.
+2. **La gravité réelle = 0,001**, pas `PHYSICS.G`. Le champ de gravité affiché est 10× trop faible.
+3. **Masses des presets** : tuner pour `poussée/gravité > 1` (G=0,001).
+4. **Orbites cinématiques** : changer une masse ne change pas les orbites.
+5. **Décollage corps mobile** : la vélocité héritée doit être `× 1000/60` (sinon glissement orbital).
+6. **Détection atterrissage/crash sur corps mobile** : actuellement ~absolue (incohérence d'unités).
+7. **Tester** tout changement physique avec le harnais headless (vrai Matter.js) — voir CHANGELOG.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,113 @@
+# TODO — Pocket Cosmos
+
+Dettes techniques, incohérences connues et feuille de route. Priorisé. Chaque item référence le code
+réel. Voir [PHYSICS.md](PHYSICS.md) pour les détails physiques, [CHANGELOG.md](CHANGELOG.md) pour
+l'historique, [CLAUDE.md](CLAUDE.md) pour l'architecture.
+
+Légende priorité : 🔴 haute · 🟠 moyenne · 🟢 basse.
+
+---
+
+## Incohérences d'unités (physique) — racine commune : delta en secondes vs Matter en ms
+
+> Contexte complet en [PHYSICS.md §1](PHYSICS.md). Le jeu passe `deltaTime` en **secondes** à
+> `Engine.update` alors que Matter suppose des **millisecondes** (`_baseDelta = 1000/60`). Donc
+> `body.velocity ≈ vitesse(u/s) × (1000/60)`. Le bon facteur de conversion `model.velocity (u/s) →
+> vitesse Matter` est **`× 1000/60`**, **pas** `× deltaTime`. Seul `handleLiftoff` est corrigé.
+
+- 🔴 **Détection atterrissage/crash de fait ABSOLUE sur corps mobiles.**
+  `CollisionHandler.getCelestialBodyVelocity` renvoie `model.velocity × dt` (~1000× trop petit) ; comparé
+  à `rocketBody.velocity` (échelle `× 1000/60`), la vélocité du corps est négligeable ⇒ la « vitesse
+  relative » est en réalité ~absolue. Atterrir/crasher sur une lune rapide est mal jugé.
+  *Action :* convertir en `× 1000/60` **et** revérifier les seuils (`LANDING_MAX_SPEED`,
+  `CRASH_SPEED_THRESHOLD`) — tester l'atterrissage sur corps mobile avant/après.
+- 🟠 **Stabilisation au sol en mauvaises unités.** `SynchronizationManager.handleLandedOrAttachedRocket`
+  (`parentVelocity = model.velocity × dt`). Masqué car la position est forcée quand on est posé, mais
+  incohérent. *Action :* aligner sur `× 1000/60`.
+- 🟠 **Vélocité de collision des corps célestes.** `PhysicsController.update` étape 1
+  (`setVelocity(body, model.velocity × lastDeltaTime)`). Le corps paraît ~immobile au solveur de
+  collision. *Action :* aligner sur `× 1000/60` (vérifier qu'aucune catapulte ne réapparaît).
+- 🟢 **Vélocité de spawn.** `GameSetupController` (spawn fusée) fait `setVelocity(host.velocity)`
+  (u/s, sans conversion). Masqué par la stabilisation. *Action :* convertir ou documenter pourquoi c'est sûr.
+- 🟢 **Centraliser la constante.** `MATTER_BASE_DELTA = 1000/60` est en dur dans `ThrusterPhysics`.
+  *Action :* l'exposer dans `constants.js` (`PHYSICS.MATTER_BASE_DELTA`) et la réutiliser partout.
+
+> ⚠️ Idéalement, **unifier toutes ces conversions** en une seule passe cohérente (helper unique) en
+> revérifiant atterrissage/crash/collision sur corps mobiles avec le harnais headless. Ne pas faire à
+> l'aveugle : ces lignes « marchent » par compensation et impactent des comportements calibrés.
+
+---
+
+## Constante de gravité
+
+- 🔴 **`gravityConstant` plugin (0,001) ≠ `PHYSICS.G` (0,0001).** La gravité réelle (plugin) n'est pas
+  celle utilisée pour la visualisation et l'IA. Conséquences : (a) le champ de gravité dessiné
+  (`VectorsView`/`PhysicsVectors` via `calculateGravity*`) est ~10× trop faible ; (b) les paramètres
+  d'orbite IA (`AI_TRAINING.ORBIT`, calculés avec G=0,0001) sont incohérents avec la physique réelle ;
+  (c) `physics.G` d'un preset ne change que la viz, pas la gravité. Voir [PHYSICS.md §2](PHYSICS.md).
+  *Action :* décider d'une source unique — soit fixer `MatterAttractors.Attractors.gravityConstant =
+  PHYSICS.G` au démarrage (⚠️ re‑tune toutes les masses des 6 mondes), soit aligner `PHYSICS.G` et les
+  calculs IA/viz sur 0,001. **Choix de design — ne pas trancher sans validation gameplay.**
+
+---
+
+## Équilibrage des mondes
+
+- 🟠 **Vérifier la décollabilité de TOUS les corps des 6 mondes.** Seul `3_outerwilds` a été
+  rééquilibré (rapport poussée/gravité visé ~1,5–3, cf. [PHYSICS.md §2.3](PHYSICS.md)). Auditer
+  `1_solar`, `2_kerbol`, `4_Tatoo`, `5_Endor`, `6_alien` : tout corps atterrissable doit avoir
+  `poussée/gravité > 1`. *Action :* script de calcul du rapport par corps + ajuster les masses ;
+  documenter les corps volontairement non‑décollables (étoiles).
+- 🟢 **Documenter le rationnel des masses** dans les JSON (commentaire d'en‑tête impossible en JSON →
+  noter dans [PHYSICS.md](PHYSICS.md)/ici).
+
+---
+
+## Hygiène / debug
+
+- 🟠 **`globalThis.DEBUG = true` laissé activé** (`constants.js`, marqué « TEMPORAIRE ») + plusieurs
+  `console.log` **inconditionnels** dans des chemins chauds (`ThrusterPhysics.handleLiftoff`,
+  `SynchronizationManager`, diagnostics `DEBUG_LIFTOFF`). *Action :* repasser `DEBUG=false` par défaut
+  et gater tous les logs derrière `if (globalThis.DEBUG)`.
+- 🟢 **Constantes en dur à remonter dans `constants.js`** : `CRASH_SINK_DEPTH = 40`
+  (`CollisionHandler`), `MATTER_BASE_DELTA`, seuils de proximité (15 px).
+
+---
+
+## Robustesse / risques
+
+- 🟠 **Rechargement d'univers pendant un décollage/atterrissage.** `SynchronizationManager` retombe sur
+  `isLanded=false` si le corps `landedOn` est introuvable ; risque de transition d'état inattendue
+  pendant un reload. *Action :* test ciblé + log explicite.
+- 🟢 **`relativePosition` recalculée une seule fois** à l'atterrissage sur corps mobile ; dérive
+  visuelle possible sur corps très rapides. *Action :* recalcul périodique si dérive mesurée.
+
+---
+
+## Architecture / scalabilité (roadmap)
+
+- 🟢 **Découper `GameController`** (monolithique : FSM, boucle, chargement d'univers, médiation
+  d'événements) en modules dédiés.
+- 🟢 **Gravité en quad‑tree** pour de grands univers (actuellement O(n) par frame sur les corps).
+- 🟢 **`GamepadController` dédié** (aujourd'hui mêlé à `InputController`/`RocketController`).
+- 🟢 **IA avancée** : Actor‑Critic / LSTM, environnements d'entraînement plus riches.
+- 🟢 **Gameplay** : étendre les missions, gestion de ressources, plus de corps célestes.
+
+---
+
+## Outillage
+
+- 🟠 **Aucun test, lint, ni build.** Test manuel uniquement. *Action :* un harnais de simulation
+  headless Node existe déjà comme preuve de concept (cf. [CHANGELOG.md](CHANGELOG.md), fix `35352c8`) —
+  l'industrialiser en tests de non‑régression physique (charger `matter-js`/`matter-attractors` via npm,
+  rejouer décollage/atterrissage et asserter les invariants). Ajouter ESLint.
+
+---
+
+## Méthode recommandée pour les changements physiques
+
+1. Lire [PHYSICS.md](PHYSICS.md) (surtout §1 unités).
+2. Reproduire/mesurer en **headless avec le vrai Matter.js** avant de coder le fix (éviter les
+   correctifs « à l'aveugle »).
+3. Comparer corps **mobile vs statique** pour isoler les effets liés au mouvement.
+4. Mettre à jour [CHANGELOG.md](CHANGELOG.md) et, si une incohérence est résolue, cet item dans TODO.md.


### PR DESCRIPTION
## Objectif
Base documentaire pour les IA travaillant sur Pocket Cosmos, décrivant **précisément le code réel**. 4 documents complémentaires qui se renvoient les uns aux autres. Faits vérifiés via un workflow de 3 agents d'exploration (lecture seule) + reproduction headless avec le vrai Matter.js.

## Fichiers
- **PHYSICS.md** (nouveau) — référence physique précise : piège d'unités `deltaTime` secondes vs Matter ms (`body.velocity ≈ u/s × 1000/60`) ; gravité réelle `G=0,001` (plugin) vs `PHYSICS.G=0,0001` (visualisation) ; rapport poussée/gravité & décollabilité ; boucle physique + synchro bidirectionnelle ; machine à états atterrissage/crash/décollage ; **tableau des conversions de vélocité avec leur exactitude** ; constantes ; pièges.
- **CHANGELOG.md** (nouveau) — historique antéchronologique groupé ; section « Non publié » avec les fixes décollage récents (hashes de commit).
- **TODO.md** (nouveau) — dettes/incohérences priorisées : unités secondes/ms restantes (détection crash de fait absolue sur corps mobiles), mismatch G plugin vs `PHYSICS.G`, `DEBUG` laissé actif, équilibrage des autres mondes, refactors, absence de tests ; + méthode recommandée pour les changements physiques.
- **CLAUDE.md** (mis à jour) — carte documentaire + renvois croisés ; corrections (ordre réel de la game loop ; `SynchronizationManager` via les events Matter, synchro bidirectionnelle ; gravité `G=0,001` réelle ; orbites cinématiques ; pipeline de rendu avec `stationView` ; `isDestroyed` au lieu de `isCrashed` ; pas de contrainte Matter au sol ; note d'incohérence sur `AI_TRAINING.ORBIT`).

Les docs distinguent explicitement ce qui est correct, ce qui « marche par effet de bord » (incohérences d'unités), et ce qui reste à faire — pour éviter les correctifs à l'aveugle.

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_