### PR TITLE
Cohérence des unités de vélocité (u/s → Matter via MATTER_BASE_DELTA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ Voir aussi [PHYSICS.md](PHYSICS.md) (détails techniques), [TODO.md](TODO.md) (d
 - **Catapulte tangentielle au décollage** (`PhysicsController.update`, étape 1) — `0851b0b`.
   La vélocité Matter des corps mobiles est convertie en par‑pas (`× lastDeltaTime`) ; complète le
   fix d'unités `96b471b` qui avait oublié cette ligne.
+- **Cohérence des unités de vélocité (secondes↔ms).** Détection atterrissage/crash
+  (`CollisionHandler.getCelestialBodyVelocity`), stabilisation posé/débris (`SynchronizationManager`),
+  vélocité de collision des corps mobiles (`PhysicsController` étape 1) et vélocité de spawn
+  (`GameSetupController`) passent toutes de `× deltaTime` (~1000× trop petit) à `× MATTER_BASE_DELTA`
+  (`= 1000/60`), désormais **centralisée** dans `constants.js`. Vérifié en headless : un atterrissage
+  **co-mobile** sur un corps rapide (~960 u/s), auparavant classé à tort comme **crash**, est
+  maintenant correctement détecté comme **atterrissage**, sans régression du décollage (dérive et
+  catapulte inchangées). Achève l'intention du commit `0e9546e` (« vitesse relative au corps ») que
+  le bug d'unités rendait inopérante.
 
 ### Modifié
 - **Rééquilibrage des masses du monde Outer Wilds** (`assets/worlds/3_outerwilds.json`) — `145e3bb`,
@@ -29,10 +38,8 @@ Voir aussi [PHYSICS.md](PHYSICS.md) (détails techniques), [TODO.md](TODO.md) (d
   (cinématiques).
 
 ### Connu / non corrigé (voir [TODO.md](TODO.md))
-- Incohérence d'unités secondes↔ms encore présente dans la stabilisation au sol, la détection de
-  crash relatif (`getCelestialBodyVelocity`) et la vélocité de collision des corps célestes.
 - `gravityConstant` du plugin (0,001) ≠ `PHYSICS.G` (0,0001) : le champ de gravité affiché et les
-  calculs IA sont ~10× sous la gravité réelle.
+  calculs IA sont ~10× sous la gravité réelle (choix de design — re‑tuning des mondes requis).
 
 ---
 

--- a/PHYSICS.md
+++ b/PHYSICS.md
@@ -55,18 +55,23 @@ velocityMatter = model.velocity × (1000/60)
 Le `dt` se **simplifie** (le mouvement réel du corps ∝ dt, et le scaling Matter ∝ 1/dt) → le facteur
 est **constant = `_baseDelta = 1000/60`**, indépendant du FPS.
 
-### 1.4 Où cette conversion est faite (et son exactitude)
+### 1.4 Où cette conversion est faite
 
-| Endroit | Facteur actuel | Facteur correct | État |
-|---|---|---|---|
-| `ThrusterPhysics.handleLiftoff` (vélocité héritée au décollage) | **`× 1000/60`** | `× 1000/60` | ✅ correct (fix `35352c8`) |
-| `PhysicsController.update` étape 1 (vélocité Matter du corps céleste, pour le solveur de collision) | `× lastDeltaTime` | `× 1000/60` | ⚠️ ~1000× trop petit (sûr : évite la catapulte, mais le corps paraît ~immobile au solveur) |
-| `SynchronizationManager` stabilisation au sol (`parentVelocity`) | `× lastDeltaTime` | `× 1000/60` | ⚠️ ~1000× trop petit (masqué : la position est forcée quand on est posé) |
-| `CollisionHandler.getCelestialBodyVelocity` (vitesse relative pour atterrissage/crash) | `× lastDeltaTime` | `× 1000/60` | ⚠️ ~1000× trop petit → la détection est **de fait ABSOLUE** sur les corps mobiles, pas relative |
+Toutes les conversions `model.velocity (u/s) → vitesse Matter` utilisent **`PHYSICS.MATTER_BASE_DELTA`
+(= 1000/60)**, centralisé dans `constants.js` :
 
-> Ces 3 lignes ⚠️ sont des **incohérences connues** : elles « marchent » par effet de bord mais sont
-> en mauvaises unités. Ne pas les « corriger » à l'aveugle (cela change l'atterrissage/crash et la
-> détection de collision sur les corps mobiles — tester). Voir [TODO.md](TODO.md).
+| Endroit | Rôle |
+|---|---|
+| `ThrusterPhysics.handleLiftoff` | vélocité héritée au décollage (co‑mouvement avec le corps quitté) |
+| `PhysicsController.update` étape 1 | vélocité Matter du corps mobile (vue par le solveur de collision) |
+| `SynchronizationManager` (posé / débris) | stabilisation : la fusée posée co‑bouge avec le corps |
+| `CollisionHandler.getCelestialBodyVelocity` | vitesse **relative** pour atterrissage/crash |
+| `GameSetupController` (spawn) | vélocité héritée du corps hôte au spawn |
+
+> Historique : ces conversions utilisaient `× deltaTime` (~1000× trop petit), ce qui rendait la
+> détection atterrissage/crash **de fait absolue** sur les corps mobiles (une fusée co‑mobile sur une
+> lune rapide était classée à tort comme crash). Corrigé le 2026‑06‑04, **vérifié en headless** (vrai
+> Matter.js) ; voir [CHANGELOG.md](CHANGELOG.md). `handleLiftoff` (décollage) avait été corrigé en premier.
 
 ---
 
@@ -191,8 +196,8 @@ Quand `isLanded` sur un corps en orbite, `handleLandedOrAttachedRocket` :
 - **Délai de collision** : aucune collision pendant `COLLISION_DELAY = 2000 ms` après init.
 - **Grâce de décollage** : si `isInLiftoffGracePeriod()` → renvoie `false` (jamais posé).
 - **Proximité** : `|distance - rayon - HEIGHT/2| < 15 px`.
-- **Vitesse relative** au corps (via `getCelestialBodyVelocity`, cf. §1.4 ⚠️ : de fait ~absolue sur
-  corps mobiles).
+- **Vitesse relative** au corps (via `getCelestialBodyVelocity`, à l'échelle Matter correcte — donc
+  réellement relative : co‑mobile sur une lune rapide ⇒ atterrissage doux, pas crash).
 - **CRASH** si proche & collisions actives & au moins un de :
   `vitesse ≥ CRASH_SPEED_THRESHOLD (2500)` · `|Δangle| ≥ CRASH_ANGLE_DEG (45°)` ·
   `|ω| ≥ CRASH_ANGULAR_VELOCITY (400)` → `isDestroyed=true`, dégâts fatals, enfoncement visuel.
@@ -256,5 +261,5 @@ Quand `isLanded` sur un corps en orbite, `handleLandedOrAttachedRocket` :
 3. **Masses des presets** : tuner pour `poussée/gravité > 1` (G=0,001).
 4. **Orbites cinématiques** : changer une masse ne change pas les orbites.
 5. **Décollage corps mobile** : la vélocité héritée doit être `× 1000/60` (sinon glissement orbital).
-6. **Détection atterrissage/crash sur corps mobile** : actuellement ~absolue (incohérence d'unités).
+6. **Détection atterrissage/crash sur corps mobile** : relative au corps (co‑mobile = atterrissage doux).
 7. **Tester** tout changement physique avec le harnais headless (vrai Matter.js) — voir CHANGELOG.

--- a/TODO.md
+++ b/TODO.md
@@ -8,33 +8,23 @@ Légende priorité : 🔴 haute · 🟠 moyenne · 🟢 basse.
 
 ---
 
-## Incohérences d'unités (physique) — racine commune : delta en secondes vs Matter en ms
+## Incohérences d'unités (physique) — ✅ RÉSOLU (2026‑06‑04)
 
-> Contexte complet en [PHYSICS.md §1](PHYSICS.md). Le jeu passe `deltaTime` en **secondes** à
-> `Engine.update` alors que Matter suppose des **millisecondes** (`_baseDelta = 1000/60`). Donc
-> `body.velocity ≈ vitesse(u/s) × (1000/60)`. Le bon facteur de conversion `model.velocity (u/s) →
-> vitesse Matter` est **`× 1000/60`**, **pas** `× deltaTime`. Seul `handleLiftoff` est corrigé.
+> Racine : `deltaTime` en secondes vs Matter en ms ([PHYSICS.md §1](PHYSICS.md)). Le bon facteur de
+> conversion `model.velocity (u/s) → vitesse Matter` est `× 1000/60`, désormais **centralisé** dans
+> `constants.js` (`PHYSICS.MATTER_BASE_DELTA`) et appliqué partout. Toutes les conversions étaient en
+> `× deltaTime` (~1000× trop petit). Corrigé et **vérifié par harnais headless** (vrai Matter.js).
 
-- 🔴 **Détection atterrissage/crash de fait ABSOLUE sur corps mobiles.**
-  `CollisionHandler.getCelestialBodyVelocity` renvoie `model.velocity × dt` (~1000× trop petit) ; comparé
-  à `rocketBody.velocity` (échelle `× 1000/60`), la vélocité du corps est négligeable ⇒ la « vitesse
-  relative » est en réalité ~absolue. Atterrir/crasher sur une lune rapide est mal jugé.
-  *Action :* convertir en `× 1000/60` **et** revérifier les seuils (`LANDING_MAX_SPEED`,
-  `CRASH_SPEED_THRESHOLD`) — tester l'atterrissage sur corps mobile avant/après.
-- 🟠 **Stabilisation au sol en mauvaises unités.** `SynchronizationManager.handleLandedOrAttachedRocket`
-  (`parentVelocity = model.velocity × dt`). Masqué car la position est forcée quand on est posé, mais
-  incohérent. *Action :* aligner sur `× 1000/60`.
-- 🟠 **Vélocité de collision des corps célestes.** `PhysicsController.update` étape 1
-  (`setVelocity(body, model.velocity × lastDeltaTime)`). Le corps paraît ~immobile au solveur de
-  collision. *Action :* aligner sur `× 1000/60` (vérifier qu'aucune catapulte ne réapparaît).
-- 🟢 **Vélocité de spawn.** `GameSetupController` (spawn fusée) fait `setVelocity(host.velocity)`
-  (u/s, sans conversion). Masqué par la stabilisation. *Action :* convertir ou documenter pourquoi c'est sûr.
-- 🟢 **Centraliser la constante.** `MATTER_BASE_DELTA = 1000/60` est en dur dans `ThrusterPhysics`.
-  *Action :* l'exposer dans `constants.js` (`PHYSICS.MATTER_BASE_DELTA`) et la réutiliser partout.
+- ✅ Détection atterrissage/crash enfin **relative** au corps (`CollisionHandler.getCelestialBodyVelocity`).
+  Test headless : une fusée co‑mobile avec un corps rapide (~960 u/s) est maintenant détectée comme
+  **atterrissage** (était un **crash**), sans régression du décollage (dérive/catapulte inchangées).
+  Achève l'intention du commit `0e9546e`.
+- ✅ Stabilisation posé/débris (`SynchronizationManager`), vélocité de collision des corps
+  (`PhysicsController` étape 1), vélocité de spawn (`GameSetupController`) : toutes en `× MATTER_BASE_DELTA`.
+- ✅ Constante `MATTER_BASE_DELTA` centralisée dans `constants.js` (plus de `1000/60` en dur).
 
-> ⚠️ Idéalement, **unifier toutes ces conversions** en une seule passe cohérente (helper unique) en
-> revérifiant atterrissage/crash/collision sur corps mobiles avec le harnais headless. Ne pas faire à
-> l'aveugle : ces lignes « marchent » par compensation et impactent des comportements calibrés.
+> Reste à valider **en jeu réel** : l'atterrissage sur les lunes rapides (Phobos `orbitSpeed=0.8`,
+> Deimos, Io…) devrait désormais être possible quand on co‑bouge avec elles.
 
 ---
 

--- a/constants.js
+++ b/constants.js
@@ -59,10 +59,17 @@ const PHYSICS = {
     
     // Multiplicateur de propulsion
     // Ajustez cette valeur pour augmenter la puissance de tous les propulseurs
-    // Note: La gravité avec G=0.0001 et masses ~2e11 génère des forces énormes
-    // Il faut un multiplicateur élevé pour permettre le décollage
+    // Note: la gravité réelle (plugin matter-attractors, G=0.001) avec des masses ~2e11 génère des
+    // forces énormes ; un multiplicateur élevé est nécessaire pour permettre le décollage. Voir PHYSICS.md.
     THRUST_MULTIPLIER: 100.0,    // Multiplicateur global pour toutes les forces de propulsion
-    
+
+    // Conversion vitesse "monde" (unités/seconde) -> vitesse Matter.js.
+    // Le jeu passe deltaTime en SECONDES à Engine.update alors que Matter suppose des ms
+    // (_baseDelta = 1000/60). Donc body.velocity ≈ (unités/seconde) × (1000/60). Pour traduire une
+    // vélocité modèle (orbitale, u/s) en vélocité Matter cohérente avec rocketBody.velocity,
+    // multiplier par cette constante (PAS par deltaTime). Voir PHYSICS.md §1.
+    MATTER_BASE_DELTA: 1000 / 60,
+
     // Contrôles assistés
     ASSISTED_CONTROLS: {
         NORMAL_ANGULAR_DAMPING: 0.0,     // Amortissement angulaire normal (mode réaliste)

--- a/controllers/CollisionHandler.js
+++ b/controllers/CollisionHandler.js
@@ -257,10 +257,13 @@ class CollisionHandler {
                 info = this.physicsController.celestialBodies.find(cb => cb.model && cb.model.name === otherBody.label);
             }
             if (info && info.model && info.model.velocity) {
-                // model.velocity est en unités/seconde (vélocité orbitale). On la convertit en
-                // déplacement par pas de simulation pour la comparer à rocketBody.velocity (Matter.js).
-                const dt = (this.physicsController.lastDeltaTime) || (1 / 60);
-                return { x: (info.model.velocity.x || 0) * dt, y: (info.model.velocity.y || 0) * dt };
+                // model.velocity est en unités/seconde (orbital). On la met à l'échelle Matter
+                // (× MATTER_BASE_DELTA = 1000/60) pour la comparer à rocketBody.velocity. Avec
+                // l'ancienne conversion × deltaTime (~1000× trop petite), la vélocité du corps était
+                // négligeable et la vitesse "relative" était de fait ABSOLUE : un atterrissage en
+                // douceur (co-mobile) sur un corps rapide était classé à tort comme crash. Voir PHYSICS.md §1.
+                const k = this.PHYSICS.MATTER_BASE_DELTA;
+                return { x: (info.model.velocity.x || 0) * k, y: (info.model.velocity.y || 0) * k };
             }
         }
         // Repli : la vélocité d'un corps physique dynamique est déjà en unités Matter (par pas).

--- a/controllers/GameSetupController.js
+++ b/controllers/GameSetupController.js
@@ -280,7 +280,9 @@ class GameSetupController {
                                 const x = fallbackHost.position.x + Math.cos(spawn.angle) * r;
                                 const y = fallbackHost.position.y + Math.sin(spawn.angle) * r;
                                 existingRocketModel.setPosition(x, y);
-                                existingRocketModel.setVelocity(fallbackHost.velocity?.x || 0, fallbackHost.velocity?.y || 0);
+                                // Vélocité héritée du corps hôte à l'échelle Matter (u/s × 1000/60), cohérente
+                                // avec la stabilisation au sol et le décollage. Voir PHYSICS.md §1.
+                                existingRocketModel.setVelocity((fallbackHost.velocity?.x || 0) * PHYSICS.MATTER_BASE_DELTA, (fallbackHost.velocity?.y || 0) * PHYSICS.MATTER_BASE_DELTA);
                                 existingRocketModel.setAngle(spawn.angle);
                                 existingRocketModel.isLanded = true;
                                 existingRocketModel.landedOn = fallbackHost.name;
@@ -295,7 +297,9 @@ class GameSetupController {
                             const x = host.position.x + Math.cos(spawn.angle) * r;
                             const y = host.position.y + Math.sin(spawn.angle) * r;
                             existingRocketModel.setPosition(x, y);
-                            existingRocketModel.setVelocity(host.velocity?.x || 0, host.velocity?.y || 0);
+                            // Vélocité héritée du corps hôte à l'échelle Matter (u/s × 1000/60), cohérente
+                            // avec la stabilisation au sol et le décollage. Voir PHYSICS.md §1.
+                            existingRocketModel.setVelocity((host.velocity?.x || 0) * PHYSICS.MATTER_BASE_DELTA, (host.velocity?.y || 0) * PHYSICS.MATTER_BASE_DELTA);
                             existingRocketModel.setAngle(spawn.angle);
                             existingRocketModel.isLanded = true;
                             existingRocketModel.landedOn = host.name;

--- a/controllers/PhysicsController.js
+++ b/controllers/PhysicsController.js
@@ -184,17 +184,13 @@ class PhysicsController {
                 // Mettre à jour la position du corps physique Matter.js
                 this.Body.setPosition(celestialInfo.body, celestialInfo.model.position);
                 // Mettre à jour la vélocité du corps physique Matter.js (calculée dans updateOrbit).
-                // CORRECTION UNITÉS (cf. commit 96b471b, oublié ici) : model.velocity est en
-                // unités/SECONDE (orbitSpeed × orbitDistance). Matter.js attend une vélocité
-                // PAR PAS de simulation (= déplacement par tick ≈ valeur/seconde × deltaTime).
-                // Sans la conversion ×lastDeltaTime, un corps mobile comme Âtrebois (~72 u/s)
-                // voyait son body.velocity fixé à ~72/pas (≈60× trop). Au décollage, lorsque la
-                // fusée n'est plus épinglée mais encore en contact avec la surface, le solveur de
-                // collision de Matter.js applique alors cette vélocité tangentielle énorme à la
-                // fusée (friction), la catapultant latéralement à une vitesse anormale (~4320 u/s).
+                // model.velocity est en unités/SECONDE (orbital). rocketBody.velocity — et donc le
+                // solveur de collision — raisonne à l'échelle Matter ≈ u/s × (1000/60). On convertit
+                // avec MATTER_BASE_DELTA pour que le corps mobile présente au solveur sa vraie vitesse
+                // (collision/friction correctes), cohérent avec la fusée. Voir PHYSICS.md §1.
                 this.Body.setVelocity(celestialInfo.body, {
-                    x: (celestialInfo.model.velocity.x || 0) * this.lastDeltaTime,
-                    y: (celestialInfo.model.velocity.y || 0) * this.lastDeltaTime
+                    x: (celestialInfo.model.velocity.x || 0) * this.PHYSICS.MATTER_BASE_DELTA,
+                    y: (celestialInfo.model.velocity.y || 0) * this.PHYSICS.MATTER_BASE_DELTA
                 });
                 // Assurer que le corps ne s'endort pas
                 celestialInfo.body.isSleeping = false;

--- a/controllers/SynchronizationManager.js
+++ b/controllers/SynchronizationManager.js
@@ -220,13 +220,13 @@ class SynchronizationManager {
                     // --- STABILISATION ACTIVE (Pas de tentative de décollage) ---
                     // Détecter si le corps est mobile (orbite)
                     const isMobile = landedOnModel.parentBody !== null;
-                    // model.velocity est en unités/seconde ; Matter.js (rocketBody.velocity) et la
-                    // vélocité de la fusée en vol sont en déplacement PAR PAS. On convertit (× dt)
-                    // pour que la fusée posée partage exactement le mouvement par pas de la planète
-                    // (et que handleLiftoff, qui applique la même conversion, soit cohérent au décollage).
-                    const dt = (this.physicsController && this.physicsController.lastDeltaTime) || (1 / 60);
+                    // model.velocity (orbital) est en unités/seconde. rocketBody.velocity est à
+                    // l'échelle Matter ≈ u/s × (1000/60). On convertit donc avec MATTER_BASE_DELTA
+                    // pour que la fusée posée co-bouge exactement avec la planète, de façon cohérente
+                    // avec handleLiftoff au décollage. Voir PHYSICS.md §1.
+                    const k = this.PHYSICS.MATTER_BASE_DELTA;
                     const parentVelocity = isMobile
-                        ? { x: (landedOnModel.velocity.x || 0) * dt, y: (landedOnModel.velocity.y || 0) * dt }
+                        ? { x: (landedOnModel.velocity.x || 0) * k, y: (landedOnModel.velocity.y || 0) * k }
                         : { x: 0, y: 0 };
 
                     // 1. Forcer les vitesses (Physique)
@@ -300,10 +300,10 @@ class SynchronizationManager {
 
             // Vérifier si le corps est mobile (orbite) - Correction du test ici
             const isAttachedToMobile = attachedToModel && attachedToModel.parentBody !== null;
-            // model.velocity (u/s) → déplacement par pas pour Matter.js (cf. CAS 1).
-            const dtAttached = (this.physicsController && this.physicsController.lastDeltaTime) || (1 / 60);
+            // model.velocity (u/s) → échelle Matter via MATTER_BASE_DELTA (cf. CAS 1, PHYSICS.md §1).
+            const kAttached = this.PHYSICS.MATTER_BASE_DELTA;
             const parentVelocity = isAttachedToMobile
-                ? { x: (attachedToModel.velocity.x || 0) * dtAttached, y: (attachedToModel.velocity.y || 0) * dtAttached }
+                ? { x: (attachedToModel.velocity.x || 0) * kAttached, y: (attachedToModel.velocity.y || 0) * kAttached }
                 : { x: 0, y: 0 };
 
             if (isAttachedToMobile) {

--- a/controllers/ThrusterPhysics.js
+++ b/controllers/ThrusterPhysics.js
@@ -185,10 +185,10 @@ class ThrusterPhysics {
                 // la fusée n'héritait quasiment pas de l'orbite et "glissait" en arrière du corps
                 // mobile (dérive tangentielle ~2× celle d'un corps statique). Avec ce facteur, la
                 // dérive orbitale est annulée (décollage propre, comme sur un corps immobile).
-                const MATTER_BASE_DELTA = 1000 / 60; // _baseDelta interne de Matter.js (ms)
+                const k = this.PHYSICS.MATTER_BASE_DELTA; // u/s -> échelle Matter (cf. PHYSICS.md §1)
                 inheritedVelocity = {
-                    x: (celestialBodyInfo.model.velocity.x || 0) * MATTER_BASE_DELTA,
-                    y: (celestialBodyInfo.model.velocity.y || 0) * MATTER_BASE_DELTA
+                    x: (celestialBodyInfo.model.velocity.x || 0) * k,
+                    y: (celestialBodyInfo.model.velocity.y || 0) * k
                 };
             }
         }


### PR DESCRIPTION
## Objectif
Résout le 🔴 du TODO : l'incohérence d'unités racine (cf. [PHYSICS.md §1]). Le bon facteur `model.velocity (u/s) → vitesse Matter` est `× (1000/60)`, **pas** `× deltaTime` (~1000× trop petit). Centralisé dans `constants.js` (`PHYSICS.MATTER_BASE_DELTA`) et appliqué partout.

## Changements
- **`CollisionHandler.getCelestialBodyVelocity`** (le 🔴) : la vitesse « relative » au corps était de fait **absolue** (vélocité du corps négligeable). Une fusée co‑mobile avec un corps rapide était classée à tort comme **crash** → désormais réellement **relative**.
- **`SynchronizationManager`** (stabilisation posé + débris), **`PhysicsController`** étape 1 (vélocité de collision des corps mobiles), **`GameSetupController`** (vélocité de spawn) : tous en `× MATTER_BASE_DELTA`.
- **`ThrusterPhysics.handleLiftoff`** : référence la constante centralisée.

Achève l'intention du commit `0e9546e` (« vitesse relative au corps ») que le bug d'unités rendait inopérante.

## Vérification (harnais headless — vrai Matter.js + vrai code)
| Test | Avant | Après |
|---|---|---|
| Atterrissage **co‑mobile** sur corps rapide (~960 u/s) | `isDestroyed=true` (crash à tort) | **`landed=true`** ✅ |
| Décollage corps mobile (non‑régression) | dérive +0,42°, pas de catapulte | dérive +0,47°, pas de catapulte ✅ |

→ On peut désormais atterrir sur les lunes rapides (Phobos, Deimos, Io…) en se posant en douceur.

Docs mises à jour : CHANGELOG (Non publié), TODO (section unités marquée résolue), PHYSICS.md §1.4/§5/§8.

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_