### PR TITLE
TODO items faciles (DEBUG, constantes, audit) + fix spawn Tatooine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,15 @@ Voir aussi [PHYSICS.md](PHYSICS.md) (détails techniques), [TODO.md](TODO.md) (d
   interplanétaire) ; *Trou blanc*/*L'Intrus* (exotiques) laissés tels quels. Orbites inchangées
   (cinématiques).
 
+### Nettoyage / hygiène
+- `globalThis.DEBUG` repassé à `false` ; les logs de décollage fréquents (`[LIFTOFF]`, `[DECOLLAGE]`)
+  gatés derrière `if (globalThis.DEBUG)`.
+- Constantes en dur centralisées dans `constants.js` : `MATTER_BASE_DELTA` (1000/60),
+  `LANDING_PROXIMITY_THRESHOLD` (15), `CRASH_SINK_DEPTH` (40).
+- Audit d'équilibrage des 6 mondes : tous les spawns sont décollables **sauf Tatooine** (`4_Tatoo`,
+  poussée/gravité ≈ 0,85) — à arbitrer. Les corps à forte gravité non‑spawn sont laissés
+  volontairement inaccessibles au vaisseau actuel (cibles de futurs vaisseaux plus puissants).
+
 ### Connu / non corrigé (voir [TODO.md](TODO.md))
 - `gravityConstant` du plugin (0,001) ≠ `PHYSICS.G` (0,0001) : le champ de gravité affiché et les
   calculs IA sont ~10× sous la gravité réelle (choix de design — re‑tuning des mondes requis).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,8 @@ Voir aussi [PHYSICS.md](PHYSICS.md) (détails techniques), [TODO.md](TODO.md) (d
   gatés derrière `if (globalThis.DEBUG)`.
 - Constantes en dur centralisées dans `constants.js` : `MATTER_BASE_DELTA` (1000/60),
   `LANDING_PROXIMITY_THRESHOLD` (15), `CRASH_SINK_DEPTH` (40).
-- Audit d'équilibrage des 6 mondes : tous les spawns sont décollables **sauf Tatooine** (`4_Tatoo`,
-  poussée/gravité ≈ 0,85) — à arbitrer. Les corps à forte gravité non‑spawn sont laissés
+- Audit d'équilibrage des 6 mondes : **tous les corps de spawn sont décollables** (Tatooine corrigé :
+  masse 3e11 → 1,4e11, ratio 0,85 → 1,82). Les corps à forte gravité non‑spawn sont laissés
   volontairement inaccessibles au vaisseau actuel (cibles de futurs vaisseaux plus puissants).
 
 ### Connu / non corrigé (voir [TODO.md](TODO.md))

--- a/PHYSICS.md
+++ b/PHYSICS.md
@@ -249,8 +249,8 @@ Quand `isLanded` sur un corps en orbite, `handleLandedOrAttachedRocket` :
 `THRUSTER_EFFECTIVENESS{MAIN:1.5, REAR:1.5, LATERAL:0.3}` ·
 `THRUSTER_POSITIONS{MAIN:{-π/2,30}, REAR:{π/2,30}, LEFT:{π,15}, RIGHT:{0,15}}`.
 
-> ⚠️ « Note magique » : `MATTER_BASE_DELTA = 1000/60` est défini en dur dans `ThrusterPhysics`.
-> Candidat à centraliser dans `constants.js` (voir [TODO.md](TODO.md)).
+> Constantes liées centralisées dans `PHYSICS` : `MATTER_BASE_DELTA` (= 1000/60, cf. §1),
+> `LANDING_PROXIMITY_THRESHOLD` (15 px), `CRASH_SINK_DEPTH` (40 px).
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -43,24 +43,31 @@ Légende priorité : 🔴 haute · 🟠 moyenne · 🟢 basse.
 
 ## Équilibrage des mondes
 
-- 🟠 **Vérifier la décollabilité de TOUS les corps des 6 mondes.** Seul `3_outerwilds` a été
-  rééquilibré (rapport poussée/gravité visé ~1,5–3, cf. [PHYSICS.md §2.3](PHYSICS.md)). Auditer
-  `1_solar`, `2_kerbol`, `4_Tatoo`, `5_Endor`, `6_alien` : tout corps atterrissable doit avoir
-  `poussée/gravité > 1`. *Action :* script de calcul du rapport par corps + ajuster les masses ;
-  documenter les corps volontairement non‑décollables (étoiles).
-- 🟢 **Documenter le rationnel des masses** dans les JSON (commentaire d'en‑tête impossible en JSON →
-  noter dans [PHYSICS.md](PHYSICS.md)/ici).
+> ⚠️ **Intention de design (confirmée)** : tous les corps n'ont PAS à être décollables avec le
+> vaisseau actuel. Certaines planètes à forte gravité sont **volontairement inaccessibles** ; des
+> vaisseaux à poussée supérieure viendront plus tard. La contrainte forte est donc : **le corps de
+> SPAWN de chaque monde DOIT être décollable** (sinon le joueur est bloqué dès le départ).
+
+- 🔴 **`4_Tatoo` : le corps de spawn (Tatooine) n'est PAS décollable** (poussée/gravité ≈ 0,85).
+  Le joueur spawn dessus et reste collé. *Action :* rendre Tatooine décollable (réduire sa masse) OU
+  déplacer le spawn — **décision de design en attente**.
+- ✅ **Audit réalisé** (script de rapport poussée/gravité par corps). Spawns décollables : Terre,
+  Kerbin, Âtrebois, Forêt‑lune d'Endor, Acheron. Corps volontairement « lourds » (géantes gazeuses /
+  étoiles binaires, non‑spawn — cibles de futurs vaisseaux) : Jupiter, Saturne, Uranus, Ohann,
+  Adriana, Endor Prime, Calpamos, Tatoo II, Zeta I/II — laissés tels quels.
+- 🟢 Cibles rocheuses < 1 hors spawn (Moho 0,60 · Minmus 0,89 · Duna 0,85 dans Kerbol) : à arbitrer si
+  on veut les rendre accessibles au vaisseau actuel (sinon, ce sont des cibles « futur vaisseau »).
 
 ---
 
 ## Hygiène / debug
 
-- 🟠 **`globalThis.DEBUG = true` laissé activé** (`constants.js`, marqué « TEMPORAIRE ») + plusieurs
-  `console.log` **inconditionnels** dans des chemins chauds (`ThrusterPhysics.handleLiftoff`,
-  `SynchronizationManager`, diagnostics `DEBUG_LIFTOFF`). *Action :* repasser `DEBUG=false` par défaut
-  et gater tous les logs derrière `if (globalThis.DEBUG)`.
-- 🟢 **Constantes en dur à remonter dans `constants.js`** : `CRASH_SINK_DEPTH = 40`
-  (`CollisionHandler`), `MATTER_BASE_DELTA`, seuils de proximité (15 px).
+- ✅ **`globalThis.DEBUG` repassé à `false`** ; les logs de décollage les plus fréquents (`[LIFTOFF]`,
+  `[DECOLLAGE]`) sont gatés derrière `if (globalThis.DEBUG)`. Reste quelques logs d'événements
+  discrets (atterrissage confirmé, position relative des débris) non gatés — gating optionnel.
+- ✅ **Constantes en dur remontées dans `constants.js`** : `LANDING_PROXIMITY_THRESHOLD` (15),
+  `CRASH_SINK_DEPTH` (40) et `MATTER_BASE_DELTA` (1000/60). Restent mineurs : `COLLISION_THRESHOLD`
+  (2,5) et le seuil de décollage local.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -48,9 +48,8 @@ Légende priorité : 🔴 haute · 🟠 moyenne · 🟢 basse.
 > vaisseaux à poussée supérieure viendront plus tard. La contrainte forte est donc : **le corps de
 > SPAWN de chaque monde DOIT être décollable** (sinon le joueur est bloqué dès le départ).
 
-- 🔴 **`4_Tatoo` : le corps de spawn (Tatooine) n'est PAS décollable** (poussée/gravité ≈ 0,85).
-  Le joueur spawn dessus et reste collé. *Action :* rendre Tatooine décollable (réduire sa masse) OU
-  déplacer le spawn — **décision de design en attente**.
+- ✅ **`4_Tatoo` : spawn Tatooine rendu décollable** (masse 3e11 → 1,4e11, ratio 0,85 → 1,82). Tous
+  les corps de spawn des 6 mondes sont désormais décollables.
 - ✅ **Audit réalisé** (script de rapport poussée/gravité par corps). Spawns décollables : Terre,
   Kerbin, Âtrebois, Forêt‑lune d'Endor, Acheron. Corps volontairement « lourds » (géantes gazeuses /
   étoiles binaires, non‑spawn — cibles de futurs vaisseaux) : Jupiter, Saturne, Uranus, Ohann,

--- a/assets/worlds/4_Tatoo.json
+++ b/assets/worlds/4_Tatoo.json
@@ -22,7 +22,7 @@
   
       {
         "name": "Tatooine",
-        "mass": 300000000000,
+        "mass": 140000000000,
         "radius": 650,
         "color": "#CFA163",
         "parentName": "Tatoo I",

--- a/constants.js
+++ b/constants.js
@@ -2,10 +2,10 @@
  * Fichier de constantes centralisées pour la simulation de fusée
  */
 
-// Drapeau global de debug (désactive les logs verbeux si false)
-// TEMPORAIRE: Activé pour le diagnostic du décollage
+// Drapeau global de debug (désactive les logs verbeux si false).
+// Mettre à true pour réactiver les logs de diagnostic (EventBus "aucun auditeur", décollage, etc.).
 if (typeof globalThis !== 'undefined' && typeof globalThis.DEBUG === 'undefined') {
-    globalThis.DEBUG = true; // Temporairement true pour voir les logs de diagnostic
+    globalThis.DEBUG = false;
 }
 
 // Constantes physiques
@@ -26,6 +26,8 @@ const PHYSICS = {
     COLLISION_DAMPING: 0.7,     // Facteur d'amortissement des collisions
     IMPACT_DAMAGE_FACTOR: 10,   // Facteur de dommages lors des impacts (appliqué sur la vitesse d'impact)
     RESTITUTION: 0.2,           // Coefficient de restitution (rebond)
+    LANDING_PROXIMITY_THRESHOLD: 15, // Distance (px) à la surface pour considérer un contact (atterrissage/crash)
+    CRASH_SINK_DEPTH: 40,            // Enfoncement visuel (px) de l'épave dans le sol lors d'un crash
 
     // ————————————————————————————————————————————————
     // Seuils de détection atterrissage/crash (utilisés par CollisionHandler)

--- a/controllers/CollisionHandler.js
+++ b/controllers/CollisionHandler.js
@@ -317,7 +317,7 @@ class CollisionHandler {
         
         const rocketEffectiveRadius = this.ROCKET.HEIGHT / 2; // Approximation du "rayon" de la fusée pour contact.
         const distanceToSurface = distance - bodyRadius - rocketEffectiveRadius;
-        const proximityThreshold = 15; // Pixels. Seuil de proximité pour considérer un contact potentiel.
+        const proximityThreshold = this.PHYSICS.LANDING_PROXIMITY_THRESHOLD; // Seuil de proximité (px) pour un contact potentiel.
         const isCloseToSurface = Math.abs(isNaN(distanceToSurface) ? Infinity : distanceToSurface) < proximityThreshold;
 
 
@@ -421,7 +421,7 @@ class CollisionHandler {
                         return false;
                     }
                     
-                    const CRASH_SINK_DEPTH = 40; // Profondeur d'enfoncement en pixels.
+                    const CRASH_SINK_DEPTH = this.PHYSICS.CRASH_SINK_DEPTH; // Profondeur d'enfoncement (px) au crash.
                     const directionX = dx / distance; // Vecteur direction normalisé.
                     const directionY = dy / distance;
                     // Nouvelle position : sur la surface moins la moitié de la hauteur de la fusée, plus la profondeur d'enfoncement.

--- a/controllers/SynchronizationManager.js
+++ b/controllers/SynchronizationManager.js
@@ -184,7 +184,7 @@ class SynchronizationManager {
                 if (mainThrusterPercent > this.PHYSICS.TAKEOFF_THRUST_THRESHOLD_PERCENT) {
                 // La fusée essaie activement de décoller, forcer isLanded à false et retourner
                 if (rocketModel.isLanded) {
-                    console.log(`[DECOLLAGE] Détection précoce: poussée=${mainThrusterPercent.toFixed(1)}%, forçant isLanded=false`);
+                    if (globalThis.DEBUG) console.log(`[DECOLLAGE] Détection précoce: poussée=${mainThrusterPercent.toFixed(1)}%, forçant isLanded=false`);
                     // IMPORTANT: Sauvegarder landedOn AVANT de le mettre à null pour le repositionnement
                     const savedLandedOn = rocketModel.landedOn;
                     rocketModel.isLanded = false;

--- a/controllers/ThrusterPhysics.js
+++ b/controllers/ThrusterPhysics.js
@@ -162,7 +162,7 @@ class ThrusterPhysics {
     // @param {string|null} forcedLandedOnName - Nom du corps (optionnel, utilisé si landedOn est déjà null)
     handleLiftoff(rocketModel, rocketBody, forcedLandedOnName = null) {
         const landedOnBodyName = forcedLandedOnName || rocketModel.landedOn;
-        console.log(`[LIFTOFF] Décollage initié depuis ${landedOnBodyName || 'surface inconnue'}`);
+        if (globalThis.DEBUG) console.log(`[LIFTOFF] Décollage initié depuis ${landedOnBodyName || 'surface inconnue'}`);
 
         // CORRECTION BUG INERTIE: Récupérer la vélocité du corps céleste AVANT de modifier l'état
         // Cela permet à la fusée d'hériter de l'inertie du corps en mouvement (lune, planète)
@@ -227,7 +227,7 @@ class ThrusterPhysics {
         };
         this.Body.setVelocity(rocketBody, liftoffVelocity);
         
-        console.log(`[LIFTOFF] ✅ Décollage naturel initié avec vélocité: (${liftoffVelocity.x.toFixed(2)}, ${liftoffVelocity.y.toFixed(2)})`);
+        if (globalThis.DEBUG) console.log(`[LIFTOFF] ✅ Décollage naturel initié avec vélocité: (${liftoffVelocity.x.toFixed(2)}, ${liftoffVelocity.y.toFixed(2)})`);
     }
 
     // Jouer le son du propulseur principal


### PR DESCRIPTION
## Contenu
Lot « items faciles » du TODO + correction du spawn de Tatooine.

### Hygiène (TODO 8)
- `globalThis.DEBUG` repassé à `false` ; logs de décollage fréquents (`[LIFTOFF]`, `[DECOLLAGE]`) gatés derrière `if (globalThis.DEBUG)`.

### Constantes (TODO 9)
- `LANDING_PROXIMITY_THRESHOLD` (15) et `CRASH_SINK_DEPTH` (40) remontées dans `constants.js` (PHYSICS) et référencées dans `CollisionHandler`.

### Audit & équilibrage des mondes (TODO 7)
- Audit poussée/gravité des 6 mondes. **Intention de design confirmée** : les corps à forte gravité hors‑spawn (géantes gazeuses, étoiles binaires) restent **volontairement inaccessibles** au vaisseau actuel (cibles de futurs vaisseaux plus puissants) — non modifiés.
- **Correction du seul vrai blocage** : le corps de **spawn de `4_Tatoo` (Tatooine)** n'était pas décollable (ratio 0,85 → joueur coincé au démarrage). Masse `3e11 → 1,4e11` ⇒ ratio **1,82**. Tous les corps de spawn des 6 mondes sont désormais décollables. Orbite inchangée (cinématique).

Docs (`TODO.md`, `CHANGELOG.md`, `PHYSICS.md`) mises à jour.

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_