### PR TITLE
Unifier la gravité (Option A) : PHYSICS.G source unique = 0,001

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,13 @@ Voir aussi [PHYSICS.md](PHYSICS.md) (détails techniques), [TODO.md](TODO.md) (d
   masse 3e11 → 1,4e11, ratio 0,85 → 1,82). Les corps à forte gravité non‑spawn sont laissés
   volontairement inaccessibles au vaisseau actuel (cibles de futurs vaisseaux plus puissants).
 
-### Connu / non corrigé (voir [TODO.md](TODO.md))
-- `gravityConstant` du plugin (0,001) ≠ `PHYSICS.G` (0,0001) : le champ de gravité affiché et les
-  calculs IA sont ~10× sous la gravité réelle (choix de design — re‑tuning des mondes requis).
+### Unification de la gravité (Option A)
+- `PHYSICS.G` devient la **source unique** : `PhysicsController.initPhysics` et `GameSetupController`
+  copient `PHYSICS.G` dans `MatterAttractors.Attractors.gravityConstant` ⇒ gravité réelle = viz = IA.
+- `PHYSICS.G` et les `physics.G` des 6 presets passés de `0,0001` à **`0,001`** (la valeur réelle déjà
+  en vigueur) → **gameplay inchangé** ; seules la visualisation du champ de gravité et l'IA (qui
+  utilisaient 0,0001) deviennent correctes. Cibles `AI_TRAINING.ORBIT` recalculées ×√10 (calibrage
+  absolu IA à valider par entraînement). Vérifié en headless : gravité réelle inchangée (0,001).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ JSON files in `assets/worlds/` can define:
 ## Physics & Matter.js
 
 - **Engine**: Matter.js 0.19.0 with the matter-attractors plugin
-- **Gravity**: Applied by the matter-attractors plugin during `Engine.update`. ⚠️ The plugin's `gravityConstant` is **0.001** (its default, never overridden in the code) — that is the REAL gravity. `PHYSICS.G` (0.0001 in `constants.js`, overridable per preset) feeds ONLY the debug/visualization and AI gravity calculations, **NOT** the actual forces.
+- **Gravity**: Applied by the matter-attractors plugin during `Engine.update`. `PHYSICS.G` (**0.001**, overridable per preset) is the SINGLE source of truth: at init and on each world load, the code copies `PHYSICS.G` into the plugin's `gravityConstant`, so **real gravity = visualization = AI**. See [PHYSICS.md §2](PHYSICS.md).
 - **Units pitfall**: the game passes `deltaTime` in **seconds** to `Engine.update`, while Matter assumes **milliseconds** (`_baseDelta = 1000/60`). Consequence: a body's `velocity` ≈ (units/second) × (1000/60). This is the root of most physics subtleties.
 - **Orbits are kinematic**: celestial bodies follow a prescribed `orbitSpeed` (not gravity), so a body's mass only affects the gravity felt by the rocket — never the bodies' own trajectories.
 - **Collision categories**: Defined in `PHYSICS.COLLISION_CATEGORIES`
@@ -193,7 +193,7 @@ The AI uses Deep Q-Network (DQN) with TensorFlow.js:
 
 **Other reward configs** (`AI_TRAINING` in `constants.js`):
 - `REWARDS`: Standard reward values for orbit, landing, and penalties
-- `ORBIT`: Orbital parameters for the `orbit` objective. ⚠️ Computed with G=0.0001, but the REAL gravity uses G=0.001 (see [PHYSICS.md](PHYSICS.md)) — a known inconsistency (see [TODO.md](TODO.md))
+- `ORBIT`: Orbital parameters for the `orbit` objective, computed with G=0.001 (consistent with the real gravity since the gravity unification). ⚠️ Absolute speed calibration vs the simulation's velocity units should still be validated by training (see [PHYSICS.md §2](PHYSICS.md))
 
 **Training methods**:
 1. Web interface: `training-interface.html` (recommended) - Full application with configuration, real-time performance charts, metrics, and trajectory visualization

--- a/PHYSICS.md
+++ b/PHYSICS.md
@@ -77,24 +77,29 @@ Toutes les conversions `model.velocity (u/s) → vitesse Matter` utilisent **`PH
 
 ## 2. Gravité
 
-### 2.1 La gravité réelle utilise G = 0,001 (pas `PHYSICS.G`)
+### 2.1 Source unique : `PHYSICS.G` (= 0,001) pilote la gravité réelle
 
 - La gravité est fournie par `MatterAttractors.Attractors.gravity`, attaché à la fusée **et** à
   chaque corps céleste dans `BodyFactory` (`plugin.attractors`).
 - Formule du plugin : `magnitude = -gravityConstant × (massA × massB) / distanceSq`.
-- `gravityConstant` du plugin = **0,001** par défaut, et **rien dans le projet ne le surcharge**
-  (vérifié : aucun set de `MatterAttractors.Attractors.gravityConstant`). → **La gravité réelle
-  utilise 0,001.**
+- **`PHYSICS.G` est la source unique.** Au démarrage (`PhysicsController.initPhysics`) et à chaque
+  chargement de monde (`GameSetupController`, après lecture de `data.physics.G`), le code copie
+  `PHYSICS.G` dans `MatterAttractors.Attractors.gravityConstant` ; le plugin lit cette valeur à chaque
+  `Engine.update`.
+- ⇒ **Gravité RÉELLE = visualisation = IA = `PHYSICS.G` (= 0,001 par défaut).** Un preset peut la
+  surcharger via `data.physics.G`, et la gravité réelle suit.
 
-### 2.2 `PHYSICS.G = 0.0001` est une valeur de VISUALISATION uniquement
+### 2.2 Visualisation & IA utilisent la même `PHYSICS.G`
 
-- `PHYSICS.G` (constants.js) et la `gravitationalConstant` de `PhysicsController` ne servent qu'aux
-  calculs de **debug/visualisation/IA** : `calculateGravityForceForDebug`, `calculateGravityAtPoint`,
-  `calculateGravityAccelerationAt` (champ de gravité affiché, vecteurs, état pour l'IA).
-- Un preset JSON peut faire `PHYSICS.G = data.physics.G` (`GameSetupController`), mais cela
-  **n'affecte QUE la visualisation/IA**, **pas** la gravité réelle du plugin.
-- ⇒ Le champ de gravité dessiné (G=0,0001) est ~**10× plus faible** que la gravité réellement subie
-  (G=0,001). Incohérence connue (voir [TODO.md](TODO.md)).
+- Les calculs de **debug/visualisation/IA** (`calculateGravityForceForDebug`, `calculateGravityAtPoint`,
+  `calculateGravityAccelerationAt` → champ de gravité affiché, vecteurs, état pour l'IA) utilisent
+  `PHYSICS.G`, **désormais égale à la gravité réelle** : le champ dessiné est fidèle et l'IA perçoit la
+  vraie gravité.
+- Les cibles d'orbite IA (`AI_TRAINING.ORBIT`) sont recalculées pour `G=0,001` (≈ ×√10 vs l'ancien
+  0,0001). ⚠️ Leur calibrage absolu en unités Matter (cf. §1) reste à valider par un entraînement réel.
+- Historique : avant le 2026‑06‑04, le plugin gardait son défaut 0,001 (jamais surchargé) tandis que
+  `PHYSICS.G=0,0001` ne servait qu'à la viz/IA → champ ~10× trop faible et IA incohérente. Unifié
+  (Option A) ; voir [CHANGELOG.md](CHANGELOG.md).
 
 ### 2.3 Décollabilité = rapport poussée/gravité (indépendant des unités)
 
@@ -236,7 +241,7 @@ Quand `isLanded` sur un corps en orbite, `handleLandedOrAttachedRocket` :
 
 ## 7. Référence des constantes (`constants.js`)
 
-**PHYSICS** : `G=0.0001` (viz) · `MAX_SPEED=10000` · `COLLISION_DELAY=2000` ·
+**PHYSICS** : `G=0.001` (source unique : gravité réelle = viz = IA, copiée dans le plugin) · `MAX_SPEED=10000` · `COLLISION_DELAY=2000` ·
 `IMPACT_DAMAGE_FACTOR=10` · `RESTITUTION=0.2` · `CRASH_SPEED_THRESHOLD=2500` ·
 `LANDING_MAX_SPEED=2500` · `LANDING_MAX_ANGLE_DEG=30` · `LANDING_MAX_ANGULAR_VELOCITY=400` ·
 `CRASH_ANGLE_DEG=45` · `CRASH_ANGULAR_VELOCITY=400` · `TAKEOFF_THRUST_THRESHOLD_PERCENT=10` ·
@@ -257,7 +262,7 @@ Quand `isLanded` sur un corps en orbite, `handleLandedOrAttachedRocket` :
 ## 8. Pièges récapitulatifs
 
 1. **Ne jamais raisonner « body.velocity = déplacement par pas ».** C'est `× 1000/60` la vitesse u/s.
-2. **La gravité réelle = 0,001**, pas `PHYSICS.G`. Le champ de gravité affiché est 10× trop faible.
+2. **La gravité réelle = `PHYSICS.G` = 0,001** (copiée dans le plugin) ; le champ de gravité affiché est fidèle.
 3. **Masses des presets** : tuner pour `poussée/gravité > 1` (G=0,001).
 4. **Orbites cinématiques** : changer une masse ne change pas les orbites.
 5. **Décollage corps mobile** : la vélocité héritée doit être `× 1000/60` (sinon glissement orbital).

--- a/TODO.md
+++ b/TODO.md
@@ -28,16 +28,17 @@ Légende priorité : 🔴 haute · 🟠 moyenne · 🟢 basse.
 
 ---
 
-## Constante de gravité
+## Constante de gravité — ✅ RÉSOLU (2026‑06‑04, Option A)
 
-- 🔴 **`gravityConstant` plugin (0,001) ≠ `PHYSICS.G` (0,0001).** La gravité réelle (plugin) n'est pas
-  celle utilisée pour la visualisation et l'IA. Conséquences : (a) le champ de gravité dessiné
-  (`VectorsView`/`PhysicsVectors` via `calculateGravity*`) est ~10× trop faible ; (b) les paramètres
-  d'orbite IA (`AI_TRAINING.ORBIT`, calculés avec G=0,0001) sont incohérents avec la physique réelle ;
-  (c) `physics.G` d'un preset ne change que la viz, pas la gravité. Voir [PHYSICS.md §2](PHYSICS.md).
-  *Action :* décider d'une source unique — soit fixer `MatterAttractors.Attractors.gravityConstant =
-  PHYSICS.G` au démarrage (⚠️ re‑tune toutes les masses des 6 mondes), soit aligner `PHYSICS.G` et les
-  calculs IA/viz sur 0,001. **Choix de design — ne pas trancher sans validation gameplay.**
+> `PHYSICS.G` est désormais la **source unique** (= 0,001) : `PhysicsController.initPhysics` et
+> `GameSetupController` copient `PHYSICS.G` dans `MatterAttractors.Attractors.gravityConstant`.
+> ⇒ gravité réelle = visualisation = IA. **Gameplay inchangé** (la gravité réelle était déjà 0,001 ;
+> seules la viz et l'IA étaient fausses). `physics.G` des 6 presets passés à 0,001. Vérifié en
+> headless (gravité réelle inchangée). Voir [PHYSICS.md §2](PHYSICS.md).
+
+- 🟢 **Reste à valider** : le calibrage absolu des cibles `AI_TRAINING.ORBIT` (recalculées ×√10 pour
+  G=0,001) face aux unités de vitesse Matter (cf. [PHYSICS.md §1](PHYSICS.md)) — à confirmer par un
+  entraînement réel de l'objectif `orbit`.
 
 ---
 

--- a/assets/worlds/1_solar.json
+++ b/assets/worlds/1_solar.json
@@ -1,7 +1,7 @@
 {
   "seed": 1001,
   "physics": {
-    "G": 0.0001,
+    "G": 0.001,
     "timeStepMs": 16.6667
   },
   "bodies": [

--- a/assets/worlds/2_kerbol.json
+++ b/assets/worlds/2_kerbol.json
@@ -1,7 +1,7 @@
 {
     "seed": 1001,
     "physics": {
-      "G": 0.0001,
+      "G": 0.001,
       "timeStepMs": 16.6667
     },
     "bodies": [

--- a/assets/worlds/3_outerwilds.json
+++ b/assets/worlds/3_outerwilds.json
@@ -1,7 +1,7 @@
 {
     "seed": 1002,
     "physics": {
-      "G": 0.0001,
+      "G": 0.001,
       "timeStepMs": 16.6667
     },
     "bodies": [

--- a/assets/worlds/4_Tatoo.json
+++ b/assets/worlds/4_Tatoo.json
@@ -1,6 +1,6 @@
 {
     "seed": 1138,
-    "physics": { "G": 0.0001, "timeStepMs": 16.6667 },
+    "physics": { "G": 0.001, "timeStepMs": 16.6667 },
     "bodies": [
       {
         "name": "Tatoo I",

--- a/assets/worlds/5_Endor.json
+++ b/assets/worlds/5_Endor.json
@@ -1,6 +1,6 @@
 {
     "seed": 1211,
-    "physics": { "G": 0.0001, "timeStepMs": 16.6667 },
+    "physics": { "G": 0.001, "timeStepMs": 16.6667 },
     "bodies": [
       {
         "name": "Moddell",

--- a/assets/worlds/6_alien.json
+++ b/assets/worlds/6_alien.json
@@ -1,6 +1,6 @@
 {
     "seed": 2049,
-    "physics": { "G": 0.0001, "timeStepMs": 16.6667 },
+    "physics": { "G": 0.001, "timeStepMs": 16.6667 },
   
     "bodies": [
       {

--- a/constants.js
+++ b/constants.js
@@ -11,10 +11,13 @@ if (typeof globalThis !== 'undefined' && typeof globalThis.DEBUG === 'undefined'
 // Constantes physiques
 const PHYSICS = {
     // Gravité
-    G: 0.0001,                // Constante gravitationnelle
-                               // REMARQUE: si un preset JSON est chargé (assets/worlds/*.json),
-                               // GameSetupController.buildWorldFromData() écrase cette valeur
-                               // avec data.physics.G pour aligner la simulation sur le monde.
+    G: 0.001,                 // Constante gravitationnelle = SOURCE UNIQUE.
+                               // C'est aussi le gravityConstant du plugin matter-attractors : au
+                               // démarrage et à chaque chargement de monde, PhysicsController et
+                               // GameSetupController copient PHYSICS.G dans
+                               // MatterAttractors.Attractors.gravityConstant. Donc gravité RÉELLE =
+                               // visualisation = IA. Un preset JSON peut l'écraser via data.physics.G.
+                               // Voir PHYSICS.md §2.
     
     // Limites et seuils
     MAX_SPEED: 10000.0,        // Vitesse maximale de la fusée
@@ -376,7 +379,7 @@ const AI_TRAINING = {
         ROCKET_INITIAL_OFFSET: 50, // Distance au-dessus de la surface
     },
     
-    // Paramètres d'orbite pour la Terre (calculés avec G=0.0001, M=2e11, R=720)
+    // Paramètres d'orbite pour la Terre (calculés avec G=0.001, M=2e11, R=720)
     ORBIT: {
         // Plage d'altitude pour considérer une orbite stable (au-dessus de la surface)
         MIN_ALTITUDE: 100,           // Altitude minimale sécuritaire
@@ -384,14 +387,17 @@ const AI_TRAINING = {
         TARGET_ALTITUDE: 500,        // Altitude cible idéale
         
         // Vitesse orbitale théorique : v = sqrt(G * M / (R + altitude))
-        // Pour altitude=500 : v = sqrt(0.0001 * 2e11 / 1220) ≈ 128
-        MIN_ORBITAL_SPEED: 100,      // Vitesse minimale pour orbite stable
-        MAX_ORBITAL_SPEED: 160,      // Vitesse maximale pour orbite stable
-        TARGET_ORBITAL_SPEED: 128,   // Vitesse orbitale cible (calculée)
+        // Pour altitude=500 : v = sqrt(0.001 * 2e11 / 1220) ≈ 405
+        // ⚠️ Calibrage absolu à valider par entraînement : la vitesse "vue" par l'IA est en unités
+        //    Matter (≈ u/s × 1000/60, cf. PHYSICS.md §1) ; ces cibles (×√10 vs l'ancien G) peuvent
+        //    devoir être re-calibrées empiriquement pour l'objectif 'orbit'.
+        MIN_ORBITAL_SPEED: 316,      // Vitesse minimale pour orbite stable
+        MAX_ORBITAL_SPEED: 506,      // Vitesse maximale pour orbite stable
+        TARGET_ORBITAL_SPEED: 405,   // Vitesse orbitale cible (calculée)
         
         // Tolérance pour considérer l'orbite réussie
         ALTITUDE_TOLERANCE: 200,     // ±200 autour de la cible
-        SPEED_TOLERANCE: 30,         // ±30 autour de la vitesse cible
+        SPEED_TOLERANCE: 95,         // ±95 autour de la vitesse cible (≈ ±30 × √10)
         
         // Nombre de pas pour confirmer une orbite stable
         STABILITY_STEPS: 100,        // ~1.67 secondes à 60 FPS

--- a/controllers/GameSetupController.js
+++ b/controllers/GameSetupController.js
@@ -157,6 +157,11 @@ class GameSetupController {
                 // du G d'un monde précédent).
                 PHYSICS.G = GameSetupController._defaultPhysicsG;
             }
+            // SOURCE UNIQUE DE GRAVITÉ : aligner la gravité RÉELLE (plugin matter-attractors) sur
+            // PHYSICS.G, pour que gravité réelle = visualisation = IA. Voir PHYSICS.md §2.
+            if (typeof MatterAttractors !== 'undefined' && MatterAttractors.Attractors) {
+                MatterAttractors.Attractors.gravityConstant = PHYSICS.G;
+            }
         } catch (e) {
             console.warn('[GameSetupController.buildWorldFromData] Impossible d\'appliquer physics.G depuis data:', e);
         }

--- a/controllers/PhysicsController.js
+++ b/controllers/PhysicsController.js
@@ -104,6 +104,12 @@ class PhysicsController {
 
         // Re-lire G : un preset chargé via UNIVERSE_LOAD_REQUESTED peut avoir muté PHYSICS.G
         this.gravitationalConstant = this.PHYSICS.G;
+        // SOURCE UNIQUE DE GRAVITÉ : la gravité RÉELLE (plugin matter-attractors) suit PHYSICS.G,
+        // de sorte que gravité réelle = visualisation = IA (cf. PHYSICS.md §2). Le plugin lit
+        // gravityConstant à chaque Engine.update ; il suffit donc de la (re)poser ici.
+        if (this.Attractors && this.Attractors.Attractors) {
+            this.Attractors.Attractors.gravityConstant = this.PHYSICS.G;
+        }
 
         // CORRECTION: Nettoyage explicite des anciens corps physiques avant reconstruction
         // Cela évite les fuites mémoire lors du rechargement d'univers


### PR DESCRIPTION
## Objectif (Option A choisie)
Unifie la gravité : `PHYSICS.G` devient la **source unique** (= 0,001). Résout le mismatch où le plugin matter‑attractors utilisait son défaut 0,001 (gravité réelle) tandis que `PHYSICS.G=0,0001` ne servait qu'à la visualisation et à l'IA (champ de gravité ~10× trop faible, IA entraînée sur une gravité fausse).

## Changements
- **Branchement** : `PhysicsController.initPhysics` et `GameSetupController` copient `PHYSICS.G` dans `MatterAttractors.Attractors.gravityConstant` (à l'init **et** à chaque chargement de monde) ⇒ gravité réelle = visualisation = IA.
- **`PHYSICS.G` : 0,0001 → 0,001** et `physics.G` des **6 presets** → 0,001 (= la valeur réelle déjà en vigueur). La gravité réelle **ne change pas** ⇒ gameplay, masses et décollabilité **inchangés** ; seules la viz du champ et l'IA deviennent correctes.
- **`AI_TRAINING.ORBIT`** recalculé pour G=0,001 (vitesses ×√10). Calibrage absolu IA à valider par entraînement (unités Matter, cf. PHYSICS.md §1).

## Vérification (harnais headless, vrai Matter.js)
- Sentinelle `PHYSICS.G=0.005` → `plugin.gravityConstant=0.005` ✅ (branchement effectif, pas un no‑op).
- Décollage et atterrissage co‑mobile **identiques** à avant ⇒ gravité réelle inchangée (0,001), gameplay préservé.

Docs mises à jour : `PHYSICS.md` (§2/§7/§8), `CLAUDE.md`, `TODO.md` (item résolu), `CHANGELOG.md`.

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_