### PR TITLE
Blinder le reload d'univers pendant un décollage (reset fusée au respawn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ Voir aussi [PHYSICS.md](PHYSICS.md) (détails techniques), [TODO.md](TODO.md) (d
   maintenant correctement détecté comme **atterrissage**, sans régression du décollage (dérive et
   catapulte inchangées). Achève l'intention du commit `0e9546e` (« vitesse relative au corps ») que
   le bug d'unités rendait inopérante.
+- **Reload d'univers pendant un décollage** (`GameSetupController.buildWorldFromData`) : le
+  `rocketModel` est désormais réinitialisé (`reset()`) avant d'appliquer le spawn. Sans cela, l'état
+  en cours (propulseurs tenus, période de grâce, `relativePosition`/`attachedTo` périmés) "fuyait"
+  dans le nouveau monde → redécollage immédiat du spawn / téléport. Vérifié en headless (avant :
+  `power=1000`, redécolle ; après : `power=0`, reste posé).
 
 ### Modifié
 - **Rééquilibrage des masses du monde Outer Wilds** (`assets/worlds/3_outerwilds.json`) — `145e3bb`,

--- a/TODO.md
+++ b/TODO.md
@@ -73,9 +73,13 @@ Légende priorité : 🔴 haute · 🟠 moyenne · 🟢 basse.
 
 ## Robustesse / risques
 
-- 🟠 **Rechargement d'univers pendant un décollage/atterrissage.** `SynchronizationManager` retombe sur
-  `isLanded=false` si le corps `landedOn` est introuvable ; risque de transition d'état inattendue
-  pendant un reload. *Action :* test ciblé + log explicite.
+- ✅ **Rechargement d'univers pendant un décollage/atterrissage** (2026‑06‑04). La simulation est déjà
+  mise en pause pendant la reconstruction, mais le même `rocketModel` était réutilisé sans purge :
+  propulseurs encore actifs → redécollage immédiat du nouveau spawn ; `relativePosition`/`attachedTo`
+  périmés → téléport ; grâce active → atterrissage non détecté. Fix : `buildWorldFromData` appelle
+  `rocketModel.reset()` avant d'appliquer le spawn. Vérifié headless (reload en tenant la poussée :
+  avant = redécollage `power=1000` ; après = reste posé `power=0`). `SynchronizationManager` efface
+  déjà `isLanded/landedOn/relativePosition` si le corps `landedOn` est introuvable.
 - 🟢 **`relativePosition` recalculée une seule fois** à l'atterrissage sur corps mobile ; dérive
   visuelle possible sur corps très rapides. *Action :* recalcul périodique si dérive mesurée.
 

--- a/controllers/GameSetupController.js
+++ b/controllers/GameSetupController.js
@@ -269,6 +269,15 @@ class GameSetupController {
             // Stocker l'info de spawn et repositionner la fusée si demandé
             if (existingRocketModel) {
                 if (data && data.rocket && data.rocket.spawn && existingRocketModel.setPosition) {
+                    // RELOAD SÛR : repartir d'un état fusée PROPRE avant d'appliquer le spawn.
+                    // Sans cela, un décollage/atterrissage en cours au moment du reload "fuit" dans le
+                    // nouveau monde : propulseurs encore actifs -> redécollage immédiat ;
+                    // relativePosition/attachedTo périmés -> téléport ; période de grâce active ->
+                    // atterrissage non détecté. reset() coupe les propulseurs, efface
+                    // grâce/relativePosition/attachedTo/destruction et restaure carburant/santé.
+                    if (typeof existingRocketModel.reset === 'function') {
+                        existingRocketModel.reset();
+                    }
                     const spawn = data.rocket.spawn;
                     universeModel.spawnInfo = JSON.parse(JSON.stringify(spawn));
                     // Mode 1: hostName + angle (spécifie l'astre de départ et l'angle à la surface)


### PR DESCRIPTION
## Problème
Lors d'un rechargement d'univers, `GameController.resetWorld` réutilise le **même** `rocketModel` et lui applique juste un nouveau spawn, **sans purger l'état en cours**. La simulation est bien mise en pause pendant la reconstruction, mais si le reload survient pendant un décollage/atterrissage :
- propulseurs encore tenus → **redécollage immédiat** du nouveau spawn ;
- `relativePosition`/`attachedTo` périmés (ancien corps) → **téléport** ;
- période de grâce active → atterrissage non détecté.

## Fix
`GameSetupController.buildWorldFromData` appelle `rocketModel.reset()` **avant** d'appliquer le spawn (coupe les propulseurs, efface grâce/`relativePosition`/`attachedTo`/destruction, restaure carburant/santé). `initPhysics` resynchronise ensuite le corps physique depuis ce modèle propre. (`SynchronizationManager` gérait déjà le cas d'un `landedOn` introuvable.)

## Vérification (harnais headless — reload en tenant la poussée, puis relâche)
| | `isLanded` | `power` | `altGain` |
|---|---|---|---|
| Avant | `false` | 1000 (hérité) | +32 (redécolle seul) |
| Après | `true` | 0 | −0,1 (reste posé) |

Docs : `TODO.md` (item résolu), `CHANGELOG.md`.

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_