### PR TITLE
Chasse aux bugs (5 agents) : nettoyage, robustesse défensive, dédup epsilon IA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,22 @@ Voir aussi [PHYSICS.md](PHYSICS.md) (détails techniques), [TODO.md](TODO.md) (d
   utilisaient 0,0001) deviennent correctes. Cibles `AI_TRAINING.ORBIT` recalculées ×√10 (calibrage
   absolu IA à valider par entraînement). Vérifié en headless : gravité réelle inchangée (0,001).
 
+### Robustesse / nettoyage (chasse aux bugs — workflow de 5 agents)
+- Code mort : abonnement à `ROCKET.CRASHED` (jamais émis) retiré de `RocketAI` — le crash passe par
+  `ROCKET.DESTROYED` ; constante `PHYSICS.MAX_SPEED` (inutilisée) retirée (`MAX_COORDINATE` conservée,
+  utilisée par `UniverseModel`).
+- `GameController._universeLoadInFlight` désormais initialisé dans le constructeur (au lieu de
+  reposer sur `undefined`).
+- Abonnement `ROCKET.RESET` de `InputController` désormais tracké via `controllerContainer`.
+- Gardes défensives : `CameraModel.screenToWorld` protège contre `zoom<=0` ; le rendu des stations
+  protège contre un `angle` non fini (coordonnées NaN).
+- IA : décroissance d'epsilon dédupliquée — gérée une seule fois par épisode par
+  `TrainingOrchestrator` (retirée de `RocketAI.handleCrash`/`handleSuccess` où elle s'ajoutait,
+  causant une décroissance ~2× trop rapide et ratant les épisodes en timeout).
+- Faux positifs écartés après vérification (aucun changement) : « fuite » `newWeights.dispose()`
+  (code correct, `setWeights` copie), overlap audio thruster, double `STATION.REFUELED`, fuites
+  d'écouteurs au reload (vues/input créés une seule fois), `bestModelWeights` (déjà libéré).
+
 ---
 
 ## 2026‑06‑02 — Stabilisation décollage & atterrissage relatif

--- a/constants.js
+++ b/constants.js
@@ -20,8 +20,7 @@ const PHYSICS = {
                                // Voir PHYSICS.md §2.
     
     // Limites et seuils
-    MAX_SPEED: 10000.0,        // Vitesse maximale de la fusée
-    MAX_COORDINATE: 10000,      // Valeur maximale de coordonnée autorisée
+    MAX_COORDINATE: 10000,      // Valeur max de coordonnée (sert à width/height de UniverseModel)
     
     // Collisions
     COLLISION_DELAY: 2000,      // Délai avant d'activer les collisions (ms)

--- a/controllers/GameController.js
+++ b/controllers/GameController.js
@@ -129,6 +129,7 @@ class GameController {
         document.addEventListener('visibilitychange', this._onVisibilityChange);
 
         this._lastRocketDestroyed = false;
+        this._universeLoadInFlight = false;
     }
     
     /**

--- a/controllers/InputController.js
+++ b/controllers/InputController.js
@@ -218,7 +218,10 @@ class InputController {
         // START n'est alors émis et le propulseur reste "fantôme" à 0. On purge donc l'état
         // d'entrée (et on émet les STOP correspondants) pour resynchroniser entrées et modèle.
         if (this.eventBus && typeof this.eventBus.subscribe === 'function') {
-            this.eventBus.subscribe(EVENTS.ROCKET.RESET, () => this._releaseAllActiveActions());
+            const _unsubReset = this.eventBus.subscribe(EVENTS.ROCKET.RESET, () => this._releaseAllActiveActions());
+            if (window.controllerContainer && typeof window.controllerContainer.track === 'function') {
+                window.controllerContainer.track(_unsubReset);
+            }
         }
 
         console.log(`[InputController] ✅ Événements initialisés, keyMap contient ${Object.keys(this.keyMap).length} touches`);

--- a/controllers/RenderingController.js
+++ b/controllers/RenderingController.js
@@ -253,8 +253,10 @@ class RenderingController {
                 // Borne à 0 : un inset supérieur au rayon (corps-hôte très petit) donnerait un
                 // rayon négatif, plaçant l'icône à l'opposé du centre.
                 const r = Math.max(0, host.radius - surfaceInset);
-                const worldX = host.position.x + Math.cos(st.angle) * r;
-                const worldY = host.position.y + Math.sin(st.angle) * r;
+                // Garde : un angle non fini (station mal formée) donnerait des coordonnées NaN.
+                const stAngle = Number.isFinite(st.angle) ? st.angle : 0;
+                const worldX = host.position.x + Math.cos(stAngle) * r;
+                const worldY = host.position.y + Math.sin(stAngle) * r;
                 const screen = this.universeView.worldToScreen(worldX, worldY, camera);
                 if (this.universeView.isPointVisible(screen.x, screen.y, camera)) {
                     // Taille proportionnelle au zoom; toujours dessiner l'icône, même très petite

--- a/controllers/RocketAI.js
+++ b/controllers/RocketAI.js
@@ -223,7 +223,7 @@ class RocketAI {
         trackSub(this.eventBus.subscribe(window.EVENTS.ROCKET.STATE_UPDATED, data => this.updateRocketData(data)));
         trackSub(this.eventBus.subscribe(window.EVENTS.AI.TOGGLE_CONTROL, () => this.toggleActive()));
         trackSub(this.eventBus.subscribe(window.EVENTS.AI.TOGGLE_TRAINING, () => this.toggleTraining()));
-        trackSub(this.eventBus.subscribe(window.EVENTS.ROCKET.CRASHED, () => this.handleCrash()));
+        // ROCKET.CRASHED n'est jamais émis (le crash passe par ROCKET.DESTROYED) -> abonnement retiré.
         trackSub(this.eventBus.subscribe(window.EVENTS.ROCKET.DESTROYED, () => this.handleCrash()));
         trackSub(this.eventBus.subscribe(window.EVENTS.MISSION.COMPLETED, () => this.handleSuccess()));
 
@@ -607,10 +607,9 @@ class RocketAI {
         this.lastAction = null;
         this.episodeSteps = 0;
         
-        // Décrémenter epsilon pour réduire l'exploration au fil du temps
-        if (this.config.epsilon > this.config.epsilonMin) {
-            this.config.epsilon *= this.config.epsilonDecay;
-        }
+        // NOTE: la décroissance d'epsilon est gérée UNE seule fois par épisode par
+        // TrainingOrchestrator (couvre crash/succès/timeout). Ne pas la dupliquer ici
+        // (sinon double décroissance par épisode -> exploration coupée trop tôt).
     }
     
     // Gestion d'un succès
@@ -639,10 +638,9 @@ class RocketAI {
         this.lastAction = null;
         this.episodeSteps = 0;
         
-        // Décrémenter epsilon pour réduire l'exploration au fil du temps
-        if (this.config.epsilon > this.config.epsilonMin) {
-            this.config.epsilon *= this.config.epsilonDecay;
-        }
+        // NOTE: la décroissance d'epsilon est gérée UNE seule fois par épisode par
+        // TrainingOrchestrator (couvre crash/succès/timeout). Ne pas la dupliquer ici
+        // (sinon double décroissance par épisode -> exploration coupée trop tôt).
     }
     
     // Entraîner le modèle avec un batch du replay buffer

--- a/models/CameraModel.js
+++ b/models/CameraModel.js
@@ -215,9 +215,12 @@ class CameraModel {
         // 1. Enlever l'offset de l'écran : (screenX - this.offsetX)
         // 2. Inverser le zoom : / this.zoom
         // 3. Ajouter la position de la caméra pour retrouver les coordonnées monde : + this.x
+        // Garde : zoom doit être > 0 (normalement clampé par setZoom, mais cette méthode publique
+        // pourrait être appelée après une affectation directe de zoom). Évite des coordonnées NaN.
+        const safeZoom = this.zoom > 0 ? this.zoom : 1;
         return {
-            x: (screenX - this.offsetX) / this.zoom + this.x,
-            y: (screenY - this.offsetY) / this.zoom + this.y
+            x: (screenX - this.offsetX) / safeZoom + this.x,
+            y: (screenY - this.offsetY) / safeZoom + this.y
         };
     }
 } 


### PR DESCRIPTION
## Contexte
Audit multi-agents (workflow de 5 agents : physique, rendering, IA, orchestration, données). **Verdict : code solide, aucun bug gameplay sévère.** Chaque finding a été vérifié — plusieurs étaient des faux positifs (écartés sans changement). Corrections de faible risque appliquées (lot A+B+C).

## A. Nettoyage code mort
- `RocketAI` : retrait de l'abonnement à `ROCKET.CRASHED` (jamais émis ; le crash passe par `ROCKET.DESTROYED`, toujours écouté).
- `constants.js` : retrait de `PHYSICS.MAX_SPEED` (inutilisé). `MAX_COORDINATE` conservé (utilisé par `UniverseModel`).
- `GameController._universeLoadInFlight` initialisé dans le constructeur.

## B. Robustesse défensive
- `InputController` : abonnement `ROCKET.RESET` tracké via `controllerContainer`.
- `CameraModel.screenToWorld` : garde `zoom<=0` (anti-NaN).
- `RenderingController` : garde angle de station non fini (anti-NaN).

## C. IA / entraînement
- Décroissance d'epsilon dédupliquée : gérée **une seule fois par épisode** par `TrainingOrchestrator` (retirée de `RocketAI.handleCrash`/`handleSuccess` où elle s'ajoutait → ~2× trop rapide et ratait les timeouts).

## Faux positifs vérifiés (aucun changement)
« Fuite critique » `newWeights.dispose()` (le code est correct, `setWeights` copie), overlap audio thruster, double `STATION.REFUELED`, fuites d'écouteurs au reload (vues/input créés une seule fois), `bestModelWeights` (déjà libéré).

## Vérification
`node --check` OK sur les 6 fichiers · epsilon `0× RocketAI / 1× orchestrator` · harnais headless inchangé (physique préservée). CHANGELOG mis à jour.

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_