### PR TITLE
Fix : l'épave suit la planète mobile après un crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ Voir aussi [PHYSICS.md](PHYSICS.md) (détails techniques), [TODO.md](TODO.md) (d
   en cours (propulseurs tenus, période de grâce, `relativePosition`/`attachedTo` périmés) "fuyait"
   dans le nouveau monde → redécollage immédiat du spawn / téléport. Vérifié en headless (avant :
   `power=1000`, redécolle ; après : `power=0`, reste posé).
+- **Épave qui ne suivait pas une planète MOBILE après un crash.** Le crash via le chemin "impact"
+  (`CollisionHandler` collisionStart, choc de côté/angle) posait `landedOn` mais **pas** `attachedTo`,
+  or le suivi de l'épave (`SynchronizationManager` CAS débris) exigeait `attachedTo` → l'épave restait
+  fixe pendant que la planète s'éloignait. Double correctif : (1) ce chemin pose désormais `attachedTo`
+  (+ `relativePosition=null`) à la destruction ; (2) le CAS débris retombe sur `landedOn` si
+  `attachedTo` est absent. Vérifié headless (corps mobile ~72 u/s : dérive de l'épave 72 u → **1,5 u**).
 
 ### Modifié
 - **Rééquilibrage des masses du monde Outer Wilds** (`assets/worlds/3_outerwilds.json`) — `145e3bb`,

--- a/controllers/CollisionHandler.js
+++ b/controllers/CollisionHandler.js
@@ -112,15 +112,23 @@ class CollisionHandler {
                             if (!rocketModel.isDestroyed) {
                                 rocketModel.landedOn = otherBody.label;
                                 const wasJustDestroyedByNonFatal = rocketModel.applyDamage(impactDamage);
-                                this.playCollisionSound(impactVelocity); 
+                                this.playCollisionSound(impactVelocity);
 
-                                if (wasJustDestroyedByNonFatal && this.physicsController && this.physicsController.eventBus) {
-                                    this.physicsController.eventBus.emit(window.EVENTS.ROCKET.DESTROYED, {
-                                        position: { ...rocketModel.position },
-                                        velocity: { ...rocketModel.velocity },
-                                        impactVelocity: impactVelocity,
-                                        destroyedOn: otherBody.label
-                                    });
+                                if (wasJustDestroyedByNonFatal) {
+                                    // L'épave doit suivre le corps (surtout s'il est MOBILE) : poser attachedTo
+                                    // active le suivi par SynchronizationManager (CAS débris). Sans cela, un crash
+                                    // via ce chemin "impact" laissait attachedTo vide et l'épave restait fixe
+                                    // pendant que la planète s'éloignait.
+                                    rocketModel.attachedTo = otherBody.label;
+                                    rocketModel.relativePosition = null;
+                                    if (this.physicsController && this.physicsController.eventBus) {
+                                        this.physicsController.eventBus.emit(window.EVENTS.ROCKET.DESTROYED, {
+                                            position: { ...rocketModel.position },
+                                            velocity: { ...rocketModel.velocity },
+                                            impactVelocity: impactVelocity,
+                                            destroyedOn: otherBody.label
+                                        });
+                                    }
                                 }
                             }
                         }

--- a/controllers/SynchronizationManager.js
+++ b/controllers/SynchronizationManager.js
@@ -292,8 +292,11 @@ class SynchronizationManager {
             }
         } // fin if(rocketModel.isLanded)
 
-        // CAS 2: Fusée détruite et attachée (logique existante semble correcte)
-        if (rocketModel.isDestroyed && rocketModel.attachedTo) {
+        // CAS 2: Fusée détruite et attachée (l'épave suit le corps).
+        // Robustesse : certains chemins de crash (collision "impact" dans CollisionHandler) ne posent
+        // que landedOn, pas attachedTo. On retombe sur landedOn pour que l'épave suive un corps MOBILE.
+        if (rocketModel.isDestroyed && (rocketModel.attachedTo || rocketModel.landedOn)) {
+            if (!rocketModel.attachedTo) rocketModel.attachedTo = rocketModel.landedOn;
             // CORRECTION: Vérifier que model existe avant d'accéder à model.name
             const attachedToInfo = celestialBodies.find(cb => cb.model && cb.model.name === rocketModel.attachedTo);
             const attachedToModel = attachedToInfo && attachedToInfo.model ? attachedToInfo.model : null;


### PR DESCRIPTION
## Problème
Au crash sur une planète **en mouvement**, l'épave restait fixe pendant que la planète s'éloignait.

## Cause (reproduite en headless)
Deux chemins de crash dans `CollisionHandler` :
- `isRocketLanded` (crashReason, choc ~perpendiculaire) → pose `attachedTo` → l'épave **suit**.
- `collisionStart` « collision significative / impact » (chocs de côté/angle, fusée pas jugée « proche surface ») → détruit la fusée mais ne posait que `landedOn`, **pas `attachedTo`**. Or le suivi de l'épave (`SynchronizationManager`, CAS débris) exigeait `attachedTo` → jamais déclenché → pas de suivi.

## Double correctif
1. **Source** (`CollisionHandler`, chemin impact) : pose `attachedTo = otherBody.label` et `relativePosition = null` à la destruction.
2. **Robustesse** (`SynchronizationManager`, CAS débris) : repli sur `landedOn` si `attachedTo` est absent.

## Vérification (harnais headless, corps mobile ~72 u/s, 1 s)
| Chemin de crash | Avant | Après |
|---|---|---|
| crashReason (`attachedTo` posé) | suit (1,5 u) | suit (1,5 u) |
| impact (`attachedTo` absent) | **ne suit pas (72 u)** | **suit (1,5 u)** |

CHANGELOG mis à jour.

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_