### PR TITLE
Chasse aux bugs (2e passe) — correctifs Tier 1 (8 bugs sûrs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ Voir aussi [PHYSICS.md](PHYSICS.md) (détails techniques), [TODO.md](TODO.md) (d
 
 ## [Non publié] — Corrections du décollage (corps mobiles) — 2026‑06‑04
 
+### Chasse aux bugs — 2e passe (5 agents), correctifs « Tier 1 » (faible risque)
+- **O1 — Les missions n'échouaient jamais à la destruction de la fusée.** La logique d'échec
+  dépendait de `ROCKET.STATE_UPDATED`, un événement **jamais émis**. Désormais déclenchée
+  directement dans `update()` à la transition `PLAYING → CRASH_ANIMATION` (appel idempotent à
+  `handleRocketStateUpdated`). Abonnement mort retiré.
+- **P2 — Décollage sous le seuil.** `ThrusterPhysics.applyThrusterForce` déclenchait `handleLiftoff`
+  dès `thrustForce > 0`, court-circuitant le seuil `TAKEOFF_THRUST_THRESHOLD_PERCENT` (10 %) appliqué
+  ailleurs : la fusée « sautait » à ~5 %. Le décollage est désormais gaté par le même seuil. Vérifié
+  headless (5 % reste posé, 50 % décolle).
+- **P1 — `isOnMobileBody` toujours vrai** (`PhysicsController`) : le test `typeof updateOrbit ===
+  'function'` (méthode de prototype, toujours présente) ne distinguait jamais un corps statique.
+  Remplacé par `parentBody != null` (cohérent avec `SynchronizationManager`). Non-régression du suivi
+  d'épave vérifiée headless.
+- **D1 — Vélocité de respawn non convertie.** `resetRocket` posait la vélocité héritée sans
+  `× MATTER_BASE_DELTA` (≠ `buildWorldFromData`) → glitch d'~1 frame au respawn sur astres mobiles
+  (mondes 3/5/6). Conversion ajoutée.
+- **O2 — Course au reload.** Une touche pressée pendant le `fetch` async d'un monde pouvait
+  relancer l'**ancien** monde (`RESUME_IF_PAUSED`). Garde ajoutée sur `_universeLoadInFlight`.
+- **O3 — Ré-atterrissage manqué après reload.** `_lastLandedEventBody` (état rémanent de
+  `SynchronizationManager`) n'était pas réinitialisé : après un reload où la fusée respawn posée sur
+  le **même** corps, `ROCKET.LANDED` n'était pas ré-émis (ravitaillement / mission « déjà posé »
+  manqués). Reset ajouté sur `UNIVERSE.STATE_UPDATED`.
+- **R1 — Frame cassée par une station mal formée.** Le rendu des stations lisait `host.position.x`
+  sans garde → `TypeError` interrompant **toute** la frame (avant fusée+UI). Gardes ajoutées sur
+  `host.position` et `host.radius`.
+- **A1 — Tracé d'entraînement corrompu.** `TrainingOrchestrator` émettait `TRAINING_STEP` avec
+  `rocketModel.x/.vx/.isCrashed` (inexistants → `undefined`/NaN). Corrigé en `position/velocity`/
+  `isDestroyed`. N'affectait que la visualisation (l'état réseau était déjà correct).
+
 ### Corrigé
 - **Décollage propre depuis un corps en orbite** (`ThrusterPhysics.handleLiftoff`) — `35352c8`.
   La vélocité orbitale héritée passe de `× deltaTime` (~0,0167, soit ~1000× trop petit) à

--- a/TODO.md
+++ b/TODO.md
@@ -85,6 +85,31 @@ Légende priorité : 🔴 haute · 🟠 moyenne · 🟢 basse.
 
 ---
 
+## Chasse aux bugs — items différés (2e passe, 5 agents)
+
+> Le « Tier 1 » (8 bugs sûrs : O1 missions, P1/P2 physique, D1 respawn, O2/O3 reload, R1 rendu,
+> A1 tracé IA) est **corrigé** — voir [CHANGELOG.md](CHANGELOG.md). Ci-dessous : trouvailles réelles
+> mais à traiter avec prudence (balance/tuning non validable sans playtest/entraînement) ou mineures.
+
+- 🟠 **P3 — Échelle des dégâts de collision.** `IMPACT_DAMAGE_FACTOR` (10) et `COLLISION_THRESHOLD`
+  (2,5) sont restés à l'ancienne échelle alors qu'`impactVelocity` est en échelle Matter (×16,67) :
+  tout contact non-atterrissage (ex. angle 30–45°) inflige des centaines de dégâts → destruction
+  quasi systématique. **Sensible au gameplay** → recalibrer + playtester (diviser `impactVelocity`
+  par `MATTER_BASE_DELTA` avant les dégâts, ou rescaler les deux constantes).
+- 🟠 **A2 — Isolation des environnements d'entraînement.** `RocketController.subscribeToEvents` n'est
+  pas idempotent et l'`EventBus` est partagé entre `trainingEnv`/`evaluationEnv` → double-abonnement
+  / cross-talk (impact borné). *Action :* désabonner avant de réabonner, ou isoler les bus.
+- 🟢 **A3/A4/A5 — Calibrage IA (navigate).** Cibles de vitesse en « units/s » vs vitesses Matter
+  (×16,67) ; `VELOCITY_SCALE` (1000) sature le vecteur d'état ; la récompense de stabilisation
+  réutilise `DISTANCE_DELTA` (100) comme poids. À valider par un **entraînement réel** avant ajustement.
+- 🟢 **Nettoyage / cosmétique.** `angularDamping` inopérant (propriété absente de Matter.js) ; events/
+  états morts (`ROCKET.CRASHED`, `ROCKET.STATE_UPDATED`, `GAME.GAME_STARTED`, états FSM inatteignables) ;
+  ceintures d'astéroïdes mondes 5/6 centrées sur l'origine (cosmétique) ; `narratives`/`timeStepMs`
+  parsés mais jamais lus ; dégradé d'anneaux « front » désaligné ; gardes de parsing preset
+  (`parentName` introuvable, `spawn.angle` manquant) sans avertissement.
+
+---
+
 ## Architecture / scalabilité (roadmap)
 
 - 🟢 **Découper `GameController`** (monolithique : FSM, boucle, chargement d'univers, médiation

--- a/controllers/GameController.js
+++ b/controllers/GameController.js
@@ -165,8 +165,9 @@ class GameController {
         window.controllerContainer.track(this.eventBus.subscribe(EVENTS.ROCKET.DECREASE_THRUST_MULTIPLIER, () => this.adjustThrustMultiplier(0.5)));
         window.controllerContainer.track(this.eventBus.subscribe(EVENTS.AI.TOGGLE_CONTROL, () => this.toggleAIControl()));
         
-        // Événement pour les mises à jour d'état de la fusée
-        window.controllerContainer.track(this.eventBus.subscribe(EVENTS.ROCKET.STATE_UPDATED, (data) => this.handleRocketStateUpdated(data)));
+        // Note : l'échec de mission à la destruction est déclenché directement dans update()
+        // (transition PLAYING -> CRASH_ANIMATION). L'ancien abonnement à ROCKET.STATE_UPDATED
+        // était mort (cet événement n'est jamais émis).
         // Événement lorsque la fusée atterrit
         window.controllerContainer.track(this.eventBus.subscribe(EVENTS.ROCKET.LANDED, (data) => this.handleRocketLanded(data)));
 
@@ -227,6 +228,9 @@ class GameController {
      * @private
      */
     handleResumeIfPaused() {
+        // Ne pas reprendre la simulation tant qu'un chargement d'univers est en cours :
+        // sinon une touche pressée pendant le fetch async ferait redémarrer l'ANCIEN monde.
+        if (this._universeLoadInFlight) return;
         if (this.currentState === GameStates.PAUSED) {
             this.changeState(GameStates.PLAYING);
         }
@@ -616,7 +620,7 @@ class GameController {
                 const x = host.position.x + Math.cos(spawn.angle) * r;
                 const y = host.position.y + Math.sin(spawn.angle) * r;
                 this.rocketModel.setPosition(x, y);
-                this.rocketModel.setVelocity(host.velocity?.x || 0, host.velocity?.y || 0);
+                this.rocketModel.setVelocity((host.velocity?.x || 0) * PHYSICS.MATTER_BASE_DELTA, (host.velocity?.y || 0) * PHYSICS.MATTER_BASE_DELTA);
                 this.rocketModel.setAngle(spawn.angle);
                 this.rocketModel.isLanded = true;
                 this.rocketModel.landedOn = host.name;
@@ -638,7 +642,7 @@ class GameController {
                 const rocketStartX = host.position.x + Math.cos(angleVersSoleil) * (host.radius + ROCKET.HEIGHT / 2 + 1);
                 const rocketStartY = host.position.y + Math.sin(angleVersSoleil) * (host.radius + ROCKET.HEIGHT / 2 + 1);
                 this.rocketModel.setPosition(rocketStartX, rocketStartY);
-                this.rocketModel.setVelocity(host.velocity?.x || 0, host.velocity?.y || 0);
+                this.rocketModel.setVelocity((host.velocity?.x || 0) * PHYSICS.MATTER_BASE_DELTA, (host.velocity?.y || 0) * PHYSICS.MATTER_BASE_DELTA);
                 this.rocketModel.setAngle(angleVersSoleil);
                 this.rocketModel.isLanded = true;
                 this.rocketModel.landedOn = host.name;
@@ -783,6 +787,9 @@ class GameController {
 
         // Vérifier les conditions de Game Over
         if (this.rocketModel && this.rocketModel.isDestroyed && this.currentState === GameStates.PLAYING) {
+            // La fusée (et son cargo) est détruite -> faire échouer les missions encore en attente.
+            // handleRocketStateUpdated est idempotent (garde _lastRocketDestroyed, remis à false au respawn).
+            this.handleRocketStateUpdated({ isDestroyed: true });
             this.changeState(GameStates.CRASH_ANIMATION); // Passer à l'animation de crash d'abord
         }
     }

--- a/controllers/PhysicsController.js
+++ b/controllers/PhysicsController.js
@@ -223,7 +223,7 @@ class PhysicsController {
                                (this.rocketModel.landedOn || this.rocketModel.attachedTo) &&
                                this.celestialBodies.some(cb =>
                                    (cb.model.name === this.rocketModel.landedOn || cb.model.name === this.rocketModel.attachedTo) &&
-                                   typeof cb.model.updateOrbit === 'function'
+                                   cb.model.parentBody != null // un corps orbite ssi il a un parent (updateOrbit, méthode de prototype, est toujours défini)
                                );
 
         const isHandledManually = isLandedOnTerre || isOnMobileBody;

--- a/controllers/RenderingController.js
+++ b/controllers/RenderingController.js
@@ -232,7 +232,9 @@ class RenderingController {
         if (universeModel && universeModel.stations && universeModel.celestialBodies && this.stationView) {
             for (const st of universeModel.stations) {
                 const host = universeModel.celestialBodies.find(b => b.name === st.hostName);
-                if (!host) continue;
+                // Garde : sans cette vérif, un hôte sans position (corps partiellement initialisé /
+                // preset mal formé) ferait lever TypeError à host.position.x, interrompant TOUTE la frame.
+                if (!host || !host.position || typeof host.position.x !== 'number' || typeof host.position.y !== 'number') continue;
                 // Positionner la station juste SOUS la surface: rayon - inset (fallback sur +offset si ancien champ).
                 // Calcul durci via variables intermédiaires + fallback numérique final garanti
                 // pour éviter tout NaN si STATIONS existe sans SURFACE_INSET ni SURFACE_OFFSET.
@@ -252,7 +254,8 @@ class RenderingController {
                 }
                 // Borne à 0 : un inset supérieur au rayon (corps-hôte très petit) donnerait un
                 // rayon négatif, plaçant l'icône à l'opposé du centre.
-                const r = Math.max(0, host.radius - surfaceInset);
+                const hostRadius = Number.isFinite(host.radius) ? host.radius : 0;
+                const r = Math.max(0, hostRadius - surfaceInset);
                 // Garde : un angle non fini (station mal formée) donnerait des coordonnées NaN.
                 const stAngle = Number.isFinite(st.angle) ? st.angle : 0;
                 const worldX = host.position.x + Math.cos(stAngle) * r;

--- a/controllers/SynchronizationManager.js
+++ b/controllers/SynchronizationManager.js
@@ -61,9 +61,11 @@ class SynchronizationManager {
         if (this.eventBus && window.EVENTS && window.EVENTS.UNIVERSE && window.EVENTS.UNIVERSE.STATE_UPDATED) {
             window.controllerContainer.track(
                 this.eventBus.subscribe(window.EVENTS.UNIVERSE.STATE_UPDATED, () => {
-                    // Les références seront automatiquement mises à jour via physicsController.celestialBodies
-                    // Mais on peut forcer une réinitialisation si nécessaire
-                    console.log('[SynchronizationManager] Univers mis à jour, références seront réinitialisées au prochain update');
+                    // Les références sont relues via physicsController.celestialBodies à chaque update.
+                    // On réinitialise l'état d'émission d'atterrissage : sinon, après un reload où la
+                    // fusée respawn posée sur le MÊME corps que précédemment, ROCKET.LANDED ne serait
+                    // pas ré-émis (ravitaillement / complétion de mission "déjà posé" manqués).
+                    this._lastLandedEventBody = null;
                 })
             );
         }

--- a/controllers/ThrusterPhysics.js
+++ b/controllers/ThrusterPhysics.js
@@ -151,8 +151,13 @@ class ThrusterPhysics {
         // La force est appliquée au point 'position' calculé précédemment
         this.Body.applyForce(rocketBody, position, { x: thrustX, y: thrustY });
 
-        // Gérer le décollage si le propulseur principal est actif et que la fusée est posée
-        if (thrusterName === 'main' && rocketModel.isLanded && thrustForce > 0) {
+        // Gérer le décollage : seulement si la fusée est posée ET la poussée principale dépasse le
+        // seuil de décollage. (Auparavant: déclenché dès thrustForce>0, ce qui faisait décoller sous
+        // le seuil 10% et court-circuitait la garde de handleLandedOrAttachedRocket.)
+        const mainMaxPower = rocketModel.thrusters && rocketModel.thrusters.main ? rocketModel.thrusters.main.maxPower : 0;
+        const mainThrustPct = mainMaxPower > 0 ? (power / mainMaxPower) * 100 : 0;
+        if (thrusterName === 'main' && rocketModel.isLanded && thrustForce > 0 &&
+            mainThrustPct > this.PHYSICS.TAKEOFF_THRUST_THRESHOLD_PERCENT) {
             // Applique une impulsion initiale pour vaincre l'inertie/gravité au sol
             this.handleLiftoff(rocketModel, rocketBody);
         }

--- a/controllers/TrainingOrchestrator.js
+++ b/controllers/TrainingOrchestrator.js
@@ -565,18 +565,20 @@ class TrainingOrchestrator {
                     step: steps,
                     episode: this.metrics.episode,
                     rocket: {
-                        position: { 
-                            x: this.trainingEnv.rocketModel.x, 
-                            y: this.trainingEnv.rocketModel.y 
+                        // CORRECTION: RocketModel expose position/velocity (objets) et isDestroyed,
+                        // pas .x/.y/.vx/.vy/.isCrashed (qui valaient undefined -> NaN dans le tracé).
+                        position: {
+                            x: this.trainingEnv.rocketModel.position.x,
+                            y: this.trainingEnv.rocketModel.position.y
                         },
-                        velocity: { 
-                            x: this.trainingEnv.rocketModel.vx, 
-                            y: this.trainingEnv.rocketModel.vy 
+                        velocity: {
+                            x: this.trainingEnv.rocketModel.velocity.x,
+                            y: this.trainingEnv.rocketModel.velocity.y
                         },
                         angle: this.trainingEnv.rocketModel.angle,
                         fuel: this.trainingEnv.rocketModel.fuel,
                         isLanded: this.trainingEnv.rocketModel.isLanded,
-                        isDestroyed: this.trainingEnv.rocketModel.isCrashed
+                        isDestroyed: this.trainingEnv.rocketModel.isDestroyed
                     },
                     celestialBodies: stepCelestialBodies
                 });


### PR DESCRIPTION
## Contexte
2e audit multi-agents (5 agents : physique, rendu, IA, orchestration, données). 24 trouvailles brutes → triées/vérifiées → **8 vrais bugs sûrs corrigés (Tier 1)**, le reste différé au [TODO.md](TODO.md). Faux positifs écartés après vérification.

## Tier 1 — corrigés
| # | Sév. | Bug |
|---|---|---|
| **O1** | Élevée | **Missions n'échouaient jamais au crash** — dépendait de `ROCKET.STATE_UPDATED` (jamais émis). Déclenché dans `update()` à la transition `PLAYING→CRASH_ANIMATION` (idempotent). Abonnement mort retiré. |
| **P2** | Moyenne | Décollage sous le seuil 10% (`applyThrusterForce` déclenchait le liftoff dès `thrustForce>0`) → gaté par `TAKEOFF_THRUST_THRESHOLD_PERCENT`. |
| **P1** | Moyenne | `isOnMobileBody` toujours vrai (`typeof updateOrbit`, méthode de prototype) → `parentBody != null`. |
| **D1** | Moyenne | `resetRocket` posait la vélocité héritée sans `×MATTER_BASE_DELTA` → glitch de respawn sur astres mobiles (mondes 3/5/6). |
| **O2** | Moyenne | Reprise possible pendant le `fetch` async d'un monde → garde `_universeLoadInFlight`. |
| **O3** | Moyenne | `_lastLandedEventBody` rémanent → `ROCKET.LANDED` pas ré-émis après reload sur le même corps (ravitaillement/mission manqués) → reset sur `UNIVERSE.STATE_UPDATED`. |
| **R1** | Moyenne | Station à l'hôte mal formé → `TypeError` cassant toute la frame → gardes `host.position`/`host.radius`. |
| **A1** | Viz | `TrainingOrchestrator` émettait `TRAINING_STEP` avec `.x/.vx/.isCrashed` (inexistants → NaN) → `position/velocity`/`isDestroyed`. |

## Vérification
`node --check` OK (6 fichiers) · harnais headless (vrai Matter.js) : suivi d'épave non régressé après P1, décollage refusé à 5% / accepté à 50% (P2). CHANGELOG + TODO à jour.

## Différé (TODO, à ne pas corriger à l'aveugle)
P3 (échelle des dégâts de collision — **balance, à playtester**), A2 (isolation des environnements d'entraînement), A3-5 (calibrage IA — **à valider par entraînement**), nettoyage cosmétique.

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_