### PR TITLE
IA : instrumenter l'échec d'entraînement + calibrer la vitesse (cohérence d'unités)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,23 @@ Voir aussi [PHYSICS.md](PHYSICS.md) (détails techniques), [TODO.md](TODO.md) (d
   `rocketModel.x/.vx/.isCrashed` (inexistants → `undefined`/NaN). Corrigé en `position/velocity`/
   `isDestroyed`. N'affectait que la visualisation (l'état réseau était déjà correct).
 
+### IA / entraînement — diagnostic (apprentissage inactif) + calibration vitesse
+- **Diagnostic instrumenté.** Sur l'interface d'entraînement : `Entraînements Réussis = 0` malgré
+  ~1,5M appels et **perte plate à 0** → `RocketAI.train()` n'aboutit jamais à la mise à jour des poids
+  (la hausse de récompense est un artefact de la décroissance d'epsilon → action fixe → la fusée fonce
+  et s'éloigne au lieu de freiner à B). Le `catch` de `train()` **avalait silencieusement** l'erreur.
+  Ajout d'un log throttlé (`_diagTrain`) sur le garde d'entrée ET dans le `catch` (hors « dispose »)
+  pour révéler la cause exacte au prochain run.
+- **Calibration vitesse par cohérence d'unités** (cibles documentées en u/s mais comparées à une
+  vitesse en échelle Matter, ×16,67) :
+  - État (`RocketAI.buildStateVector`) : `vx/vy` ramenés en **u/s** (÷ `MATTER_BASE_DELTA`) → fin de la
+    **saturation** (croisière ~382 u/s : feature 2,000 saturé → **0,382** informatif, vérifié en node).
+  - Récompenses navigate (`calculateVelocityReward`, stabilisation, `checkNavigateSuccess`) : vitesse
+    mesurée en **u/s** via `_rocketSpeedUnitsPerSec()` → cibles `VELOCITY_TARGET/MAX` et seuil de succès
+    enfin cohérents (avant, la vitesse de croisière requise était **pénalisée**).
+  - Stabilisation : poids dédié `STABILIZE_REWARD_WEIGHT` (au lieu de réutiliser `DISTANCE_DELTA=100`).
+  > ⚠️ Valeurs absolues à **valider par un entraînement réel** une fois l'apprentissage rétabli.
+
 ### Corrigé
 - **Décollage propre depuis un corps en orbite** (`ThrusterPhysics.handleLiftoff`) — `35352c8`.
   La vélocité orbitale héritée passe de `× deltaTime` (~0,0167, soit ~1000× trop petit) à

--- a/TODO.md
+++ b/TODO.md
@@ -99,9 +99,15 @@ Légende priorité : 🔴 haute · 🟠 moyenne · 🟢 basse.
 - 🟠 **A2 — Isolation des environnements d'entraînement.** `RocketController.subscribeToEvents` n'est
   pas idempotent et l'`EventBus` est partagé entre `trainingEnv`/`evaluationEnv` → double-abonnement
   / cross-talk (impact borné). *Action :* désabonner avant de réabonner, ou isoler les bus.
-- 🟢 **A3/A4/A5 — Calibrage IA (navigate).** Cibles de vitesse en « units/s » vs vitesses Matter
-  (×16,67) ; `VELOCITY_SCALE` (1000) sature le vecteur d'état ; la récompense de stabilisation
-  réutilise `DISTANCE_DELTA` (100) comme poids. À valider par un **entraînement réel** avant ajustement.
+- 🔴 **Apprentissage IA inactif (`successfulTrainings = 0`).** `RocketAI.train()` est appelé ~1,5M
+  fois mais n'aboutit JAMAIS à une mise à jour des poids (perte plate à 0 ; la hausse de récompense est
+  un artefact de la décroissance d'epsilon). Instrumentation throttlée ajoutée (`_diagTrain` + `catch`
+  non muet `RocketAI.js`). *Action :* **relancer ~30 s d'entraînement et lire la console** (`[RocketAI.train]
+  guard:` vs `fit:`) pour la cause exacte (garde l.652 vs exception `model.fit`), puis corriger la racine.
+- ✅ **A3/A4/A5 — Calibrage vitesse IA (cohérence d'unités).** État + récompenses navigate + succès
+  mesurés en **u/s** (÷ `MATTER_BASE_DELTA`) ; dé-saturation du vecteur d'état vérifiée (croisière
+  0,382 au lieu de 2,0 saturé) ; poids de stabilisation dédié `STABILIZE_REWARD_WEIGHT`. **Valeurs
+  absolues à valider par un entraînement** une fois l'apprentissage rétabli (item ci-dessus).
 - 🟢 **Nettoyage / cosmétique.** `angularDamping` inopérant (propriété absente de Matter.js) ; events/
   états morts (`ROCKET.CRASHED`, `ROCKET.STATE_UPDATED`, `GAME.GAME_STARTED`, états FSM inatteignables) ;
   ceintures d'astéroïdes mondes 5/6 centrées sur l'origine (cosmétique) ; `narratives`/`timeStepMs`

--- a/constants.js
+++ b/constants.js
@@ -452,7 +452,8 @@ const AI_TRAINING = {
         // Stabilisation au point B
         BRAKE_ZONE_RATIO: 0.2,      // En dessous de 20% de distance, réduire la vitesse cible
         STABILIZE_ZONE_RATIO: 0.1,  // En dessous de 10%, forte récompense pour vitesse quasi nulle
-        STABILIZE_SPEED_REF: 100,   // Vitesse de référence pour le calcul de stabilisation
+        STABILIZE_SPEED_REF: 100,   // Vitesse de référence (u/s) pour le calcul de stabilisation
+        STABILIZE_REWARD_WEIGHT: 10, // Poids dédié du bonus de stabilisation (avant: DISTANCE_DELTA=100 réutilisé à tort)
 
         // Récompenses de terminaison
         SUCCESS_REWARD: 1000,        // Récompense finale pour succès (proche ET stabilisé)

--- a/controllers/HeadlessRocketEnvironment.js
+++ b/controllers/HeadlessRocketEnvironment.js
@@ -716,16 +716,14 @@ class HeadlessRocketEnvironment {
         reward += zoneReward;
 
         // 6. Stabilisation Reward - Bonus pour ralentir près du point B
-        const speed = Math.sqrt(
-            this.rocketModel.velocity.x ** 2 +
-            this.rocketModel.velocity.y ** 2
-        );
+        const speed = this._rocketSpeedUnitsPerSec(); // u/s (réf. STABILIZE_SPEED_REF en u/s)
         const distRatio = currentDistance / (this._initialDistanceToTarget || 1);
         const stabilizeZone = config.STABILIZE_ZONE_RATIO || 0.1;
         const stabilizeSpeedRef = config.STABILIZE_SPEED_REF || 100;
         if (distRatio < stabilizeZone) {
             // Proche du point B : forte récompense pour vitesse basse
-            const stabilReward = Math.max(0, 1 - speed / stabilizeSpeedRef) * (config.DISTANCE_DELTA || 50);
+            const stabilWeight = (typeof config.STABILIZE_REWARD_WEIGHT === 'number') ? config.STABILIZE_REWARD_WEIGHT : 10;
+            const stabilReward = Math.max(0, 1 - speed / stabilizeSpeedRef) * stabilWeight;
             reward += stabilReward;
         }
 
@@ -809,13 +807,19 @@ class HeadlessRocketEnvironment {
      * 3. Velocity Control Reward - Récompense pour vitesse optimale
      * La vitesse cible diminue à l'approche du point B pour forcer le freinage.
      */
+    // Vitesse de la fusée en unités/s. Le modèle stocke la vélocité en échelle Matter
+    // (≈ u/s × 1000/60) ; les cibles NAVIGATE_REWARDS et seuils de succès sont définis en u/s.
+    _rocketSpeedUnitsPerSec() {
+        const k = (typeof PHYSICS !== 'undefined' && PHYSICS.MATTER_BASE_DELTA) ? PHYSICS.MATTER_BASE_DELTA : (1000 / 60);
+        const vx = (this.rocketModel && this.rocketModel.velocity) ? (this.rocketModel.velocity.x || 0) : 0;
+        const vy = (this.rocketModel && this.rocketModel.velocity) ? (this.rocketModel.velocity.y || 0) : 0;
+        return Math.sqrt(vx * vx + vy * vy) / k;
+    }
+
     calculateVelocityReward(targetPoint, config) {
         if (!this.rocketModel || !this.rocketModel.velocity) return 0;
 
-        const speed = Math.sqrt(
-            this.rocketModel.velocity.x ** 2 +
-            this.rocketModel.velocity.y ** 2
-        );
+        const speed = this._rocketSpeedUnitsPerSec(); // u/s (cibles VELOCITY_* en u/s)
 
         // Vitesse cible adaptative : proportionnelle à la distance restante
         // Loin → vitesse croisière, Proche → quasi immobile
@@ -1278,10 +1282,7 @@ class HeadlessRocketEnvironment {
         const dy = this.rocketModel.position.y - targetPoint.y;
         const distance = Math.sqrt(dx * dx + dy * dy);
 
-        const speed = Math.sqrt(
-            this.rocketModel.velocity.x ** 2 +
-            this.rocketModel.velocity.y ** 2
-        );
+        const speed = this._rocketSpeedUnitsPerSec(); // u/s (seuil SUCCESS_SPEED_THRESHOLD en u/s)
 
         // Succès = proche du point B ET stabilisé (vitesse quasi nulle)
         const SUCCESS_DISTANCE_THRESHOLD = 3000;

--- a/controllers/RocketAI.js
+++ b/controllers/RocketAI.js
@@ -376,8 +376,12 @@ class RocketAI {
         const num = (v) => (typeof v === 'number' && isFinite(v)) ? v : 0;
         const x = num(p.x);
         const y = num(p.y);
-        const vx = Math.max(-2000, Math.min(2000, num(p.vx)));
-        const vy = Math.max(-2000, Math.min(2000, num(p.vy)));
+        // Le modèle stocke la vélocité en échelle Matter (≈ u/s × 1000/60). On la ramène en u/s
+        // (cohérent avec VELOCITY_SCALE) pour ne plus saturer : auparavant clampée à ±2000 puis
+        // /1000 -> toujours ±2, le réseau ne "voyait" jamais la magnitude de vitesse réelle.
+        const VK = (typeof PHYSICS !== 'undefined' && PHYSICS.MATTER_BASE_DELTA) ? PHYSICS.MATTER_BASE_DELTA : (1000 / 60);
+        const vx = Math.max(-3000, Math.min(3000, num(p.vx) / VK));
+        const vy = Math.max(-3000, Math.min(3000, num(p.vy) / VK));
         const angle = num(p.angle);
         const angularVelocity = Math.max(-50, Math.min(50, num(p.angularVelocity)));
         const targetX = num(p.targetX);
@@ -650,6 +654,7 @@ class RocketAI {
         
         // Vérifier que les modèles existent, ne sont pas disposés et sont prêts
         if (!this.model || !this.targetModel || this.isDisposed || !this.modelReady) {
+            this._diagTrain('guard', `model=${!!this.model} targetModel=${!!this.targetModel} disposed=${this.isDisposed} ready=${this.modelReady}`);
             return;
         }
         
@@ -788,7 +793,11 @@ class RocketAI {
                 this.concurrencyMetrics.successfulTrainings;
             
         } catch (error) {
-            // Ignorer silencieusement les erreurs (dont "disposed")
+            // Tracer l'erreur réelle (throttlé) au lieu de l'avaler silencieusement : c'est ce
+            // silence qui masquait pourquoi l'entraînement n'aboutissait pas (successfulTrainings=0).
+            // Les erreurs liées à un "dispose" restent ignorées (attendues à l'arrêt).
+            const _msg = (error && error.message) ? error.message : String(error);
+            if (!/dispos/i.test(_msg)) this._diagTrain('fit', _msg);
         } finally {
             // Libérer la mémoire tensor (si les tenseurs existent)
             if (xs) { try { xs.dispose(); } catch (e) {} }
@@ -916,6 +925,17 @@ class RocketAI {
         }
     }
     
+    // Diagnostic throttlé : pourquoi train() n'aboutit pas (successfulTrainings reste à 0).
+    // Loggue au plus une fois / 2 s par catégorie (évite le spam sur des milliers d'appels).
+    _diagTrain(tag, msg) {
+        const now = Date.now();
+        if (!this._trainDiag) this._trainDiag = {};
+        if (now - (this._trainDiag[tag] || 0) > 2000) {
+            this._trainDiag[tag] = now;
+            try { console.warn('[RocketAI.train] ' + tag + ' : ' + msg); } catch (e) {}
+        }
+    }
+
     // Obtenir les métriques de concurrence
     getConcurrencyMetrics() {
         return {


### PR DESCRIPTION
## Contexte
Suite au retour de l'interface d'entraînement : **« Entraînements Réussis = 0 »** malgré ~1,5M appels et une **perte plate à 0** → `RocketAI.train()` n'aboutit jamais à une mise à jour des poids. La hausse de récompense est un artefact de la décroissance d'epsilon (action fixe → la fusée fonce et s'éloigne au lieu de freiner à B).

## 1. Instrumentation (trouver la cause au prochain run)
Le `catch` de `train()` **avalait silencieusement** l'erreur. Ajout d'un log throttlé (`_diagTrain`, ≤ 1×/2 s par catégorie) :
- dans le `catch` (hors « dispose ») → exception récurrente de `model.fit()` ;
- sur le garde d'entrée → `model`/`targetModel`/`disposed`/`modelReady`.

→ relancer ~30 s, lire la console : `[RocketAI.train] guard:` vs `[RocketAI.train] fit:`.

## 2. Calibration vitesse (cohérence d'unités)
Cibles documentées en u/s mais comparées à une vitesse en échelle Matter (×16,67) :
- **`buildStateVector`** : `vx/vy` ramenés en u/s (÷ `MATTER_BASE_DELTA`) → fin de la saturation. **Vérifié en node** sur la vraie fonction : croisière ~382 u/s → feature **0,382** (au lieu de **2,000 saturé**).
- **`HeadlessRocketEnvironment`** : vitesse navigate en u/s via `_rocketSpeedUnitsPerSec()` (`calculateVelocityReward`, stabilisation, `checkNavigateSuccess`) → `VELOCITY_TARGET/MAX` et seuil de succès cohérents (avant, la vitesse de croisière requise était **pénalisée**).
- **A5** : poids dédié `STABILIZE_REWARD_WEIGHT` (au lieu de réutiliser `DISTANCE_DELTA`).

> ⚠️ Valeurs absolues à **valider par un entraînement réel** une fois l'apprentissage rétabli.

`node --check` OK (3 fichiers). CHANGELOG + TODO à jour.

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_