### PR TITLE
train.js : sonde testUpdateFrequency fiable (await init + vrais updates)

### DIFF
--- a/train.js
+++ b/train.js
@@ -476,7 +476,14 @@ async function testUpdateFrequency() {
     try {
         const eventBus = new EventBus();
         const rocketAI = new RocketAI(eventBus);
-        
+
+        // CORRECTION : attendre la création ASYNCHRONE du modèle. Sinon train() ressort
+        // immédiatement à la garde (model=null, ready=false) et ce test ne mesure RIEN de réel
+        // (il affichait "25/25 PARFAIT" alors qu'aucun poids n'était mis à jour).
+        console.log('Attente de l\'initialisation du modèle (waitForReady)...');
+        await rocketAI.waitForReady();
+        console.log(`Modèle prêt: model=${!!rocketAI.model} targetModel=${!!rocketAI.targetModel} ready=${rocketAI.modelReady}`);
+
         console.log(`Configuration: updateFrequency = ${rocketAI.config.updateFrequency} pas`);
         
         // Compter les updates pendant une simulation courte
@@ -532,13 +539,18 @@ async function testUpdateFrequency() {
         console.log(`   Updates attendus: ${expectedUpdates}`);
         console.log(`   Updates réels: ${updateCount}`);
         console.log(`   Ratio: ${updateCount}/${targetSteps} = ${(updateCount/targetSteps*100).toFixed(1)}%`);
-        
-        if (updateCount === expectedUpdates) {
-            console.log(`   ✅ PARFAIT! Fréquence respectée.`);
-        } else if (updateCount > expectedUpdates * 0.8) {
-            console.log(`   ⚡ CORRECT, légère variation acceptable.`);
+
+        // APPELS vs APPRENTISSAGE RÉEL : updateCount ne compte que les APPELS à train().
+        // Ce qui compte, c'est successfulTrainings (poids réellement mis à jour par model.fit).
+        const m = rocketAI.concurrencyMetrics;
+        console.log(`   Appels train(): ${m.totalTrainingCalls} | bloqués: ${m.blockedCalls} | RÉUSSIS: ${m.successfulTrainings}`);
+        console.log(`   Dernier loss: ${m.lastLoss}`);
+
+        if (m.successfulTrainings > 0 && typeof m.lastLoss === 'number' && isFinite(m.lastLoss) && m.lastLoss > 0) {
+            console.log(`   ✅ APPRENTISSAGE RÉEL OK : les poids sont mis à jour (loss=${m.lastLoss.toFixed(5)}).`);
         } else {
-            console.log(`   ❌ PROBLÈME: Trop peu d'updates réels.`);
+            console.log(`   ❌ AUCUN apprentissage réel : train() est appelé mais ne met pas à jour les poids.`);
+            console.log(`      -> voir les lignes [RocketAI.train] ci-dessus (guard/inprogress/fit) pour la cause.`);
         }
         
         // Restaurer la fonction originale


### PR DESCRIPTION
## Cause racine du « guard: model=false »
Le run a montré :
```
[RocketAI.train] guard : model=false targetModel=false disposed=false ready=false
```
…émis depuis **`testUpdateFrequency()`**. C'est un **bug du test**, pas du vrai entraînement : il appelle `train()` **sans attendre l'init asynchrone** du modèle (`initModel().then(...)`), donc `this.model` est `null` et `train()` ressort à la garde. Le test affichait pourtant « 25/25 PARFAIT » parce qu'il comptait les **appels**, pas les **updates réelles**.

## Correctifs (`train.js`)
- `await rocketAI.waitForReady()` avant de remplir le buffer / appeler `train()`.
- Verdict basé sur `concurrencyMetrics.successfulTrainings` + `lastLoss` (apprentissage **réel**) au lieu du compte d'appels → **OK** vs **AUCUN apprentissage réel** (avec renvoi vers les tags `[RocketAI.train]`).

## Ce qui est confirmé sain
- `initModel()` (création + compile + repli CPU) et `waitForReady()` sont **corrects** ; aucune erreur d'init dans les logs.
- `diagnosticComplet()` attend déjà `waitForReady`.
- Le vrai orchestrateur attend aussi l'init (`TrainingOrchestrator` l.355‑356) → ce correctif **ne change pas** le chemin d'entraînement réel, il rend juste la **sonde fiable**.

## Prochain pas
Lancer la `testUpdateFrequency()` corrigée → si « ✅ APPRENTISSAGE RÉEL OK (loss=…) », le cœur DQN apprend ; on pivote alors vers le compteur de l'UI / le chemin orchestrateur.

`node --check` OK.

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_