### PR TITLE
Orchestrateur : tracer buffer/isTraining/batchSize (pourquoi train() n'est jamais appelé)

### DIFF
--- a/controllers/TrainingOrchestrator.js
+++ b/controllers/TrainingOrchestrator.js
@@ -542,7 +542,19 @@ class TrainingOrchestrator {
             totalReward += result.reward;
             done = result.done;
             steps++;
-            
+
+            // DIAGNOSTIC throttlé (<=1x/2s) : pourquoi train() peut ne jamais se déclencher.
+            // Montre si le buffer se remplit, si l'agent est en mode entraînement, et la valeur
+            // réelle de batchSize/updateFreq (un batchSize undefined rendrait la condition l.532
+            // toujours fausse -> train() jamais appelé -> aucun tag [RocketAI.train]).
+            const _nowDiag = Date.now();
+            if (!this._lastEpDiag || _nowDiag - this._lastEpDiag > 2000) {
+                this._lastEpDiag = _nowDiag;
+                try {
+                    console.warn(`[Orchestrator] ep=${this.metrics.episode} steps=${steps} buffer=${this.rocketAI.replayBuffer.length}/${this.config.batchSize} aiTraining=${this.rocketAI.isTraining} updateFreq=${this.rocketAI.config.updateFrequency}`);
+                } catch (e) {}
+            }
+
             // IMPORTANT: Céder le contrôle au navigateur périodiquement pour garder l'UI réactive
             // Toutes les 50 steps pour un bon équilibre performance/réactivité
             if (steps % 50 === 0) {


### PR DESCRIPTION
## Constat
L'utilisateur confirme : **aucun tag `[RocketAI.train]`** pendant le vrai entraînement. Comme la 1ʳᵉ ligne utile de `train()` loggue toujours un tag, **`train()` n'est jamais appelé par l'orchestrateur**.

Le buffer ne se remplit qu'à la condition `this.rocketAI.isTraining` (l.515), et `train()` n'est appelé qu'à `replayBuffer.length >= this.config.batchSize` (l.532). Il faut voir lequel coince.

## Ajout
Log throttlé (≤ 1×/2 s) en fin de boucle d'épisode :
```
[Orchestrator] ep=… steps=… buffer=<len>/<batchSize> aiTraining=<bool> updateFreq=…
```
→ tranche immédiatement entre : **buffer vide** (push non exécuté), **`isTraining` faux**, ou **`batchSize` undefined** (rendrait la condition toujours fausse).

`node --check` OK.

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_