### PR TITLE
Orchestrateur : sonder le site d'appel de train() (typeof/hasDiag/exception)

### DIFF
--- a/controllers/TrainingOrchestrator.js
+++ b/controllers/TrainingOrchestrator.js
@@ -531,10 +531,21 @@ class TrainingOrchestrator {
             if (this.rocketAI && !this.rocketAI.isDisposed &&
                 this.rocketAI.replayBuffer.length >= this.config.batchSize &&
                 steps % this.rocketAI.config.updateFrequency === 0) {
+                // DIAGNOSTIC throttlé : prouver que ce site est atteint et que train est appelable.
+                // hasDiag=undefined => le RocketAI.js servi est une version en CACHE (sans nos logs).
+                const _nowT = Date.now();
+                if (!this._lastTrainCallDiag || _nowT - this._lastTrainCallDiag > 2000) {
+                    this._lastTrainCallDiag = _nowT;
+                    try { console.warn(`[Orchestrator] -> appel train() typeof=${typeof this.rocketAI.train} hasDiag=${typeof this.rocketAI._diagTrain} successfulTrainings=${this.rocketAI.concurrencyMetrics ? this.rocketAI.concurrencyMetrics.successfulTrainings : '?'}`); } catch (e) {}
+                }
                 try {
                     await this.rocketAI.train();
                 } catch (trainError) {
-                    // Ignorer silencieusement
+                    const _m = (trainError && trainError.message) ? trainError.message : String(trainError);
+                    if (!this._lastTrainErrDiag || _nowT - this._lastTrainErrDiag > 2000) {
+                        this._lastTrainErrDiag = _nowT;
+                        try { console.error('[Orchestrator] train() a levé une exception:', _m); } catch (e) {}
+                    }
                 }
             }
             


### PR DESCRIPTION
## Paradoxe à résoudre
Le diagnostic orchestrateur montre :
```
[Orchestrator] ep=10 steps=18601 buffer=218601/32 aiTraining=true updateFreq=4
```
→ la condition d'appel de `train()` (l.531‑533 : `buffer ≥ 32 && steps%4==0`) est **largement satisfaite**, mais **aucun tag `[RocketAI.train]`** n'apparaît. Donc soit :
1. `train()` lève une exception **avalée** par le `catch` silencieux (l.536) ;
2. le `RocketAI.js` servi par GitHub Pages est une **version en cache** (sans nos `_diagTrain`).

## Sonde ajoutée (juste avant l'appel)
```
[Orchestrator] -> appel train() typeof=<…> hasDiag=<…> successfulTrainings=<…>
```
- `typeof` → `train` est‑il appelable ?
- **`hasDiag=undefined`** → le `RocketAI.js` chargé est un **cache obsolète** (sans mes logs) → la racine est le déploiement, pas le code.
- `successfulTrainings` → grimpe-t-il malgré l'absence de tag ?
- le `catch` **loggue** désormais l'exception au lieu de l'avaler.

`node --check` OK.

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_