### PR TITLE
FIX racine : updateTargetModel() disposait les poids vivants du modèle (0 entraînement)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,13 +38,18 @@ Voir aussi [PHYSICS.md](PHYSICS.md) (détails techniques), [TODO.md](TODO.md) (d
   `rocketModel.x/.vx/.isCrashed` (inexistants → `undefined`/NaN). Corrigé en `position/velocity`/
   `isDestroyed`. N'affectait que la visualisation (l'état réseau était déjà correct).
 
-### IA / entraînement — diagnostic (apprentissage inactif) + calibration vitesse
-- **Diagnostic instrumenté.** Sur l'interface d'entraînement : `Entraînements Réussis = 0` malgré
-  ~1,5M appels et **perte plate à 0** → `RocketAI.train()` n'aboutit jamais à la mise à jour des poids
-  (la hausse de récompense est un artefact de la décroissance d'epsilon → action fixe → la fusée fonce
-  et s'éloigne au lieu de freiner à B). Le `catch` de `train()` **avalait silencieusement** l'erreur.
-  Ajout d'un log throttlé (`_diagTrain`) sur le garde d'entrée ET dans le `catch` (hors « dispose »)
-  pour révéler la cause exacte au prochain run.
+### IA / entraînement — RACINE corrigée (apprentissage enfin actif) + calibration vitesse
+- **🎯 BUG RACINE : `updateTargetModel()` détruisait les poids du modèle.** L'« optimisation
+  memory leak » faisait `this.model.getWeights().forEach(w => w.dispose())` — or `getWeights()`
+  renvoie les **tenseurs vivants des variables** (pas des copies). Résultat : dès `initModel`, le
+  noyau `dense_Dense1/kernel` était disposé, et **`model.fit()` levait `LayersVariable … is already
+  disposed` à CHAQUE appel** → `successfulTrainings` restait à 0, perte plate, aucun apprentissage.
+  L'epsilon initial à 1.0 (actions aléatoires) masquait le défaut : la fusée bougeait sans jamais
+  utiliser le réseau. **Correctif : `targetModel.setWeights(model.getWeights())` sans aucun dispose.**
+- **Diagnostic instrumenté** (qui a permis de remonter à la racine) : `train()` instrumenté sur
+  toutes ses sorties (`guard`/`buffer`/`inprogress`/`fit-start`/`ok` + 5 `return`), `catch`
+  dé-filtré, et traces côté `TrainingOrchestrator` (taille du buffer, `isTraining`, site d'appel).
+  `testUpdateFrequency()` rendu fiable (attend `waitForReady`, rapporte les updates réelles).
 - **Calibration vitesse par cohérence d'unités** (cibles documentées en u/s mais comparées à une
   vitesse en échelle Matter, ×16,67) :
   - État (`RocketAI.buildStateVector`) : `vx/vy` ramenés en **u/s** (÷ `MATTER_BASE_DELTA`) → fin de la

--- a/controllers/RocketAI.js
+++ b/controllers/RocketAI.js
@@ -187,16 +187,14 @@ class RocketAI {
         }
         
         try {
-            // CORRECTION MEMORY LEAK: Dispose les anciens et nouveaux poids après utilisation
-            const oldWeights = this.targetModel.getWeights();
-            const newWeights = this.model.getWeights();
-            this.targetModel.setWeights(newWeights);
-            // Libérer les anciens poids (copies retournées par getWeights)
-            oldWeights.forEach(w => w.dispose());
-            // Libérer aussi les nouveaux poids car setWeights() crée ses propres copies
-            newWeights.forEach(w => w.dispose());
+            // getWeights() renvoie les tenseurs VIVANTS des variables des modèles (PAS des copies) ;
+            // setWeights() recopie leurs valeurs dans les variables de la cible. Il ne faut donc PAS
+            // les disposer : le faire libérait les poids des modèles eux-mêmes, d'où l'erreur
+            // "LayersVariable dense_Dense1/kernel is already disposed" qui faisait échouer model.fit()
+            // à CHAQUE appel (successfulTrainings restait à 0 -> aucun apprentissage).
+            this.targetModel.setWeights(this.model.getWeights());
         } catch (error) {
-            // Ignorer les erreurs de dispose silencieusement
+            // Ignorer les erreurs silencieusement
         }
     }
     


### PR DESCRIPTION
## 🎯 Cause racine de `successfulTrainings = 0`
Le `catch` dé‑filtré a enfin révélé l'erreur réelle :
```
[RocketAI.train] fit : LayersVariable dense_Dense1/kernel is already disposed.
```

Dans `updateTargetModel()`, sous couvert d'une « CORRECTION MEMORY LEAK » :
```js
const newWeights = this.model.getWeights();
this.targetModel.setWeights(newWeights);
newWeights.forEach(w => w.dispose());   // ← détruit les poids DU modèle principal
oldWeights.forEach(w => w.dispose());   // ← idem côté target
```
`getWeights()` renvoie les **tenseurs vivants des variables** (pas des copies). Les disposer libère `dense_Dense1/kernel` **dès `initModel()`** → `model.fit()` lève `already disposed` à **chaque** appel → 0 entraînement, perte plate. L'epsilon initial à 1.0 (actions aléatoires) masquait le défaut : la fusée bougeait sans jamais solliciter le réseau.

## Correctif
```js
this.targetModel.setWeights(this.model.getWeights()); // sans aucun dispose
```
Pattern DQN standard : ces tenseurs sont gérés par TF.js, pas de fuite.

## Comment on y est arrivé
Instrumentation progressive de `train()` (toutes ses sorties) et de `TrainingOrchestrator` (buffer/`isTraining`/site d'appel), `catch` dé‑filtré, et `testUpdateFrequency()` fiabilisé.

`node --check` OK. CHANGELOG à jour.

> Prochaine étape : confirmer `[RocketAI.train] ok: … loss=…` + `Entraînements Réussis` qui grimpe, puis **nettoyer les traces de debug** et juger la calibration vitesse.

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_