### PR TITLE
Entraînement headless réellement rapide (saute le rendu par step + cède rarement)

### DIFF
--- a/controllers/TrainingOrchestrator.js
+++ b/controllers/TrainingOrchestrator.js
@@ -572,14 +572,17 @@ class TrainingOrchestrator {
                 }
             }
 
-            // IMPORTANT: Céder le contrôle au navigateur périodiquement pour garder l'UI réactive
-            // Toutes les 50 steps pour un bon équilibre performance/réactivité
-            if (steps % 50 === 0) {
+            // IMPORTANT: Céder le contrôle au navigateur périodiquement pour garder l'UI réactive.
+            // En mode headless (sans rendu) on cède beaucoup plus rarement -> entraînement nettement
+            // plus rapide ; en mode visuel on cède souvent pour garder l'animation fluide.
+            const _yieldEvery = this.config.headlessMode ? 500 : 50;
+            if (steps % _yieldEvery === 0) {
                 await new Promise(resolve => setTimeout(resolve, 0));
             }
-            
-            // Émettre l'événement de step pour la visualisation (toutes les 10 étapes pour les performances)
-            if (steps % 10 === 0 && this.trainingEnv.rocketModel) {
+
+            // Émettre l'événement de step pour la visualisation (toutes les 10 étapes).
+            // Inutile en mode headless (aucun rendu) -> on l'évite pour accélérer l'entraînement.
+            if (!this.config.headlessMode && steps % 10 === 0 && this.trainingEnv.rocketModel) {
                 const stepCelestialBodies = (this.trainingEnv.universeModel && this.trainingEnv.universeModel.celestialBodies) 
                     ? this.trainingEnv.universeModel.celestialBodies.map(body => ({
                         name: body.name,


### PR DESCRIPTION
## Problème
Le sélecteur propose **« Sans rendu (rapide) »** (headless) vs **« Avec visualisation »**, mais la boucle d'entraînement émettait les événements de visualisation (toutes les 10 steps) et cédait au navigateur via `setTimeout(0)` (toutes les 50 steps) **même en headless** → le mode « rapide » ne l'était pas vraiment.

## Correctif
- **Headless** : on n'émet plus `TRAINING_STEP` (aucun rendu à alimenter → suppression d'allocations + événements par step).
- **Cession au navigateur** : toutes les **500 steps** en headless (vs 50 en visuel) → beaucoup moins d'overhead `setTimeout` (clampé ~4 ms).

Le mode **visuel reste inchangé** (animation fluide pour observer, avec la bascule de vue). Pour un entraînement long → choisir **« Sans rendu (rapide) »**.

`node --check` OK.

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_