### PR TITLE
Interface entraînement : curseur de vitesse ⏩ ×1→×20 (mode visuel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ Voir aussi [PHYSICS.md](PHYSICS.md) (détails techniques), [TODO.md](TODO.md) (d
   `window.DEBUG_AI = true` ; les vraies erreurs de `model.fit` restent toujours remontées. Le replay
   buffer (poussé directement par l'orchestrateur) est **borné** à `replayBufferSize` (avant : croissance
   illimitée, ~270 000 entrées observées → fuite mémoire).
+- **Vitesse d'entraînement.** Le mode « Sans rendu (rapide) » est désormais réellement rapide (plus
+  d'émission d'événements de rendu par step, cession au navigateur 10× plus rare). En mode visuel, un
+  **curseur de vitesse ⏩ ×1→×20** règle la cadence de rendu (1 rendu tous les `10 × vitesse` steps)
+  pour observer en avance rapide ; modifiable **en direct** pendant l'entraînement.
 
 ### Corrigé
 - **Décollage propre depuis un corps en orbite** (`ThrusterPhysics.handleLiftoff`) — `35352c8`.

--- a/controllers/TrainingOrchestrator.js
+++ b/controllers/TrainingOrchestrator.js
@@ -32,6 +32,7 @@ class TrainingOrchestrator {
             // Configuration environnement
             headlessMode: true,
             logInterval: 50,
+            visualSpeed: 1, // Mode visuel : cadence de rendu (×1 = fluide … ×20 = avance rapide)
             
             // Objectifs d'entraînement
             // CORRECTION (bug défaut objectif): la doc décrit 'navigate' comme objectif par
@@ -573,16 +574,17 @@ class TrainingOrchestrator {
             }
 
             // IMPORTANT: Céder le contrôle au navigateur périodiquement pour garder l'UI réactive.
-            // En mode headless (sans rendu) on cède beaucoup plus rarement -> entraînement nettement
-            // plus rapide ; en mode visuel on cède souvent pour garder l'animation fluide.
-            const _yieldEvery = this.config.headlessMode ? 500 : 50;
+            // Headless : on cède rarement (rapide). Visuel : la cadence dépend du curseur de vitesse
+            // (×1 = fluide ; ×N = on saute N fois plus de steps entre deux rendus -> avance rapide).
+            const _speed = Math.max(1, this.config.visualSpeed || 1);
+            const _yieldEvery = this.config.headlessMode ? 500 : Math.min(500, 50 * _speed);
             if (steps % _yieldEvery === 0) {
                 await new Promise(resolve => setTimeout(resolve, 0));
             }
 
-            // Émettre l'événement de step pour la visualisation (toutes les 10 étapes).
-            // Inutile en mode headless (aucun rendu) -> on l'évite pour accélérer l'entraînement.
-            if (!this.config.headlessMode && steps % 10 === 0 && this.trainingEnv.rocketModel) {
+            // Émettre l'événement de step pour la visualisation. Inutile en headless ; en visuel on
+            // rend tous les (10 × vitesse) steps -> plus la vitesse est haute, moins on rend (= rapide).
+            if (!this.config.headlessMode && steps % (10 * _speed) === 0 && this.trainingEnv.rocketModel) {
                 const stepCelestialBodies = (this.trainingEnv.universeModel && this.trainingEnv.universeModel.celestialBodies) 
                     ? this.trainingEnv.universeModel.celestialBodies.map(body => ({
                         name: body.name,

--- a/training-interface.html
+++ b/training-interface.html
@@ -346,6 +346,10 @@
                 <div class="visualization-controls">
                     <button id="toggleVisualization">👁️ Activer</button>
                     <button id="toggleView">🌌 Vue absolue</button>
+                    <label title="Vitesse de l'animation (×1 fluide … ×20 avance rapide)" style="display:flex; align-items:center; gap:4px; color:#aaa; font-size:0.85em;">
+                        ⏩ <input type="range" id="visualSpeed" min="1" max="20" step="1" value="1" style="width:70px; vertical-align:middle;">
+                        <span id="visualSpeedLabel" style="min-width:30px; display:inline-block;">×1</span>
+                    </label>
                     <button id="clearTrajectory">🧹 Effacer</button>
                     <button id="zoomOut" class="zoom-button">➖</button>
                     <button id="zoomIn" class="zoom-button">➕</button>
@@ -654,6 +658,7 @@
                 // Événements de visualisation
                 document.getElementById('toggleVisualization').addEventListener('click', () => this.toggleVisualization());
                 document.getElementById('toggleView').addEventListener('click', () => this.toggleView());
+                document.getElementById('visualSpeed').addEventListener('input', (e) => this.onVisualSpeedChanged(e.target.value));
                 document.getElementById('clearTrajectory').addEventListener('click', () => this.clearTrajectory());
                 document.getElementById('zoomIn').addEventListener('click', () => this.zoomIn());
                 document.getElementById('zoomOut').addEventListener('click', () => this.zoomOut());
@@ -796,6 +801,7 @@
                         gamma: config.gamma,
                         batchSize: config.batchSize,
                         headlessMode: config.trainingMode === 'headless',
+                        visualSpeed: this.visualSpeed || 1,
                         objectives: [config.objective]
                     };
                     
@@ -1194,6 +1200,17 @@
                     const btn = document.getElementById('toggleView');
                     if (btn) btn.textContent = following ? '🌌 Vue absolue' : '🚀 Vue vaisseau';
                     this.log(following ? 'Vue vaisseau (suivi de la fusée)' : 'Vue absolue (centrée A↔B)', 'info');
+                }
+            }
+
+            onVisualSpeedChanged(value) {
+                const speed = Math.max(1, Math.min(20, parseInt(value) || 1));
+                this.visualSpeed = speed;
+                const label = document.getElementById('visualSpeedLabel');
+                if (label) label.textContent = '×' + speed;
+                // Appliquer immédiatement, même pendant un entraînement en cours.
+                if (this.trainingOrchestrator && this.trainingOrchestrator.config) {
+                    this.trainingOrchestrator.config.visualSpeed = speed;
                 }
             }
         }


### PR DESCRIPTION
## Demande
Un **curseur de vitesse** pour regarder l'entraînement en avance rapide (sans devoir passer en headless).

## Implémentation
- **`TrainingOrchestrator`** : la cadence dépend de `config.visualSpeed` —
  - rendu émis tous les `10 × vitesse` steps (×1 = tous les 10, ×20 = tous les 200),
  - cession au navigateur tous les `min(500, 50 × vitesse)` steps.
- **`training-interface.html`** : curseur **⏩ (range 1→20)** dans les contrôles de visualisation, libellé **×N** live, appliqué **immédiatement** via `this.trainingOrchestrator.config.visualSpeed` (même pendant un entraînement en cours) et transmis au démarrage.

Plus la vitesse est haute, moins on rend → l'animation « fast-forward » et la boucle va plus vite. Le mode headless reste l'option maximale (aucun rendu).

`node --check` OK. CHANGELOG à jour.

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_