### PR TITLE
Curseur de vitesse : throttle la boucle de rendu du visualiseur (vraie avance rapide)

### DIFF
--- a/controllers/TrainingVisualizer.js
+++ b/controllers/TrainingVisualizer.js
@@ -478,14 +478,23 @@ class TrainingVisualizer {
      */
     startRenderLoop() {
         if (this.renderLoopId) return;
-        
+
+        let frame = 0;
         const render = () => {
             if (this.isActive) {
-                this.render();
+                // Saute des frames quand la vitesse visuelle est élevée (curseur ⏩) : le rendu de la
+                // trajectoire est coûteux et monopolise le thread principal (il s'exécute entre chaque
+                // model.fit). En n'affichant qu'1 frame sur N, on libère le thread pour la boucle
+                // d'entraînement -> la simulation avance réellement plus vite (avance rapide).
+                const skip = Math.max(1, this.renderEveryNFrames || 1);
+                if (frame % skip === 0) {
+                    this.render();
+                }
+                frame++;
                 this.renderLoopId = requestAnimationFrame(render);
             }
         };
-        
+
         this.renderLoopId = requestAnimationFrame(render);
     }
     

--- a/training-interface.html
+++ b/training-interface.html
@@ -1208,9 +1208,15 @@
                 this.visualSpeed = speed;
                 const label = document.getElementById('visualSpeedLabel');
                 if (label) label.textContent = '×' + speed;
-                // Appliquer immédiatement, même pendant un entraînement en cours.
+                // Appliquer immédiatement, même pendant un entraînement en cours :
+                // 1) l'orchestrateur émet les événements de rendu et cède au navigateur moins souvent ;
                 if (this.trainingOrchestrator && this.trainingOrchestrator.config) {
                     this.trainingOrchestrator.config.visualSpeed = speed;
+                }
+                // 2) le visualiseur saute des frames de rendu (libère le thread pour l'entraînement).
+                //    C'est ce qui rend l'avance rapide réellement plus rapide.
+                if (this.visualizer) {
+                    this.visualizer.renderEveryNFrames = speed;
                 }
             }
         }


### PR DESCRIPTION
## Problème
Le curseur de vitesse s'affichait mais **n'accélérait pas** en pratique.

## Cause
Le visualiseur tourne sa **propre boucle `requestAnimationFrame` ~60 fps** (`startRenderLoop`) qui dessine la trajectoire en continu et **monopolise le thread principal** (elle s'exécute entre chaque `model.fit`). Mon réglage initial ne touchait que l'émission d'événements et la cession au navigateur côté orchestrateur → la fusée atteignait B au **même instant**, seulement plus saccadée.

## Correctif
La boucle de rendu n'affiche plus qu'**1 frame sur N** (N = vitesse), via `visualizer.renderEveryNFrames`, piloté **en direct** par le curseur. À ×20, le rendu passe de ~60 fps à ~3 fps → le thread est libéré pour la boucle d'entraînement → **la simulation avance réellement plus vite**. Combiné aux cessions/émissions déjà throttlées côté orchestrateur.

`node --check` OK.

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_