### PR TITLE
Navigate : temps de vol A→B réduit ~5× (budget 4000 steps + vitesses ×5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@ Voir aussi [PHYSICS.md](PHYSICS.md) (détails techniques), [TODO.md](TODO.md) (d
   d'émission d'événements de rendu par step, cession au navigateur 10× plus rare). En mode visuel, un
   **curseur de vitesse ⏩ ×1→×20** règle la cadence de rendu (1 rendu tous les `10 × vitesse` steps)
   pour observer en avance rapide ; modifiable **en direct** pendant l'entraînement.
+- **Temps de vol A→B réduit ~5×.** Budget d'épisode navigate `20000 → 4000` steps (~66 s) + cibles de
+  vitesse mises à l'échelle ×5 (`VELOCITY_TARGET 500 → 2500` u/s, `MAX 2000 → 10000`, `SIGMA 200 → 1000`,
+  `MIN 50 → 250`) pour que la fusée croise assez vite et atteigne B dans le budget réduit.
+  ⚠️ À valider par un entraînement (freinage/stabilisation plus serrés).
 
 ### Corrigé
 - **Décollage propre depuis un corps en orbite** (`ThrusterPhysics.handleLiftoff`) — `35352c8`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ The AI uses Deep Q-Network (DQN) with TensorFlow.js:
 - **Visualization**: `TrainingVisualizer.js` - Real-time training metrics with navigation point display
 
 **Training objectives**:
-- `navigate` - Point-to-point navigation (default): the rocket must fly from point A `(0,0)` to point B `(90000, 90000)` (~127k units diagonal), then **brake and stabilize** at point B. Success requires distance < 3000 AND speed < 30. Random initial angle forces the AI to learn orientation. Budget: 20000 steps, infinite fuel.
+- `navigate` - Point-to-point navigation (default): the rocket must fly from point A `(0,0)` to point B `(90000, 90000)` (~127k units diagonal), then **brake and stabilize** at point B. Success requires distance < 3000 AND speed < 30. Random initial angle forces the AI to learn orientation. Budget: **4000 steps** (~66s @ 1/60s — flight ~5× shorter; cruise target `VELOCITY_TARGET` ≈ 2500 u/s), infinite fuel.
 - `orbit` - Achieve stable orbit at target altitude
 - `land` - Soft landing on a celestial body
 - `crash` - (used for crash avoidance training)

--- a/constants.js
+++ b/constants.js
@@ -439,11 +439,11 @@ const AI_TRAINING = {
         // PRIORITÉ BASSE - Optimisation théorique
         POTENTIAL: 1.0,              // Potential-Based Reward (priorité basse) - Potential-based reward shaping
 
-        // Paramètres de vitesse (distance A-B ~127k unités, budget ~20k steps)
-        VELOCITY_TARGET: 500.0,      // Vitesse cible optimale (unités/s)
-        VELOCITY_SIGMA: 200.0,       // Écart-type pour gaussienne de vitesse
-        VELOCITY_MIN: 50.0,          // Vitesse minimale acceptable
-        VELOCITY_MAX: 2000.0,        // Vitesse maximale acceptable
+        // Paramètres de vitesse (distance A-B ~127k unités, budget ~4k steps → vol ~5× plus rapide)
+        VELOCITY_TARGET: 2500.0,     // Vitesse de croisière cible (u/s) — ×5 pour un temps de vol plus court
+        VELOCITY_SIGMA: 1000.0,      // Écart-type pour la gaussienne de vitesse
+        VELOCITY_MIN: 250.0,         // Vitesse minimale acceptable
+        VELOCITY_MAX: 10000.0,       // Vitesse maximale acceptable (avant pénalité)
 
         // Zones progressives (ratio de distance initiale)
         ZONE_REWARDS: [10, 25, 50, 100], // Récompenses par zone (croissantes, augmentées)

--- a/controllers/TrainingOrchestrator.js
+++ b/controllers/TrainingOrchestrator.js
@@ -211,8 +211,9 @@ class TrainingOrchestrator {
             // Angle initial aléatoire pour forcer l'IA à s'orienter
             const rocketInitialAngle = Math.random() * Math.PI * 2;
 
-            // Budget de steps : distance ~127k, vitesse cible ~500 m/s → ~254s → ~15000 steps
-            const navigateMaxSteps = Math.max(this.config.maxStepsPerEpisode, 20000);
+            // Budget de steps réduit ~5× (vol plus court A→B). Distance ~127k unités, croisière
+            // cible ~2500 u/s → ~51s → ~3000 steps de croisière + freinage ⇒ 4000 steps (66s @ 1/60s).
+            const navigateMaxSteps = Math.max(this.config.maxStepsPerEpisode, 4000);
 
             // IMPORTANT: Mettre à jour this.config pour que la boucle d'entraînement (runEpisode)
             // utilise aussi cette limite, pas seulement l'environnement


### PR DESCRIPTION
## Demande
« Le temps de vol est trop long. 5× moins de temps de vol serait suffisant pour aller de A vers B. »

## Analyse
1 step = **1/60 s**. Budget actuel **20000 steps = 333 s**, distance A→B = **127 279 unités** → croisière nécessaire ~382 u/s, d'où `VELOCITY_TARGET=500`. Budget et vitesse étaient **cohérents mais lents**.

Réduire le budget **seul** rendrait B inatteignable (à 500 u/s il faut ~15000 steps). Il faut donc **aussi** accélérer la croisière.

## Rescale ×5 cohérent
- **Budget** épisode navigate `20000 → 4000` steps (~66 s).
- **Vitesses** (`constants.js`) : `VELOCITY_TARGET 500 → 2500` u/s, `VELOCITY_MAX 2000 → 10000`, `VELOCITY_SIGMA 200 → 1000`, `VELOCITY_MIN 50 → 250`.

À 2500 u/s, la fusée croise 127 279 unités en ~51 s (~3000 steps) + freinage → tient dans 4000 steps. La fusée est physiquement capable de ces vitesses (jusqu'à ~6300 u/s observées). Distance A→B et critères de succès (dist < 3000, vit < 30 u/s) **inchangés**.

> ⚠️ À **valider par un entraînement** : freinage/stabilisation à B sont plus serrés (5× moins de marge). Si trop dur, on remontera le budget (ex. 5000–6000).

`node --check` OK. CLAUDE.md + CHANGELOG à jour.

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_