### PR TITLE
README : lien vers l'interface d'entraînement après le lien de la simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Prenez les commandes ! Ce projet vous permet de piloter une fusée dans un mini-
 
 - [Lancer la Simulation](https://habib256.github.io/pocketcosmos/index.html)
   _(Cliquez pour essayer !)_ ✨
+- [Interface d'Entraînement IA](https://habib256.github.io/pocketcosmos/training-interface.html)
+  _(Entraîner l'IA à piloter de A vers B !)_ 🤖
 
 ### Captures d'écran 📸
 


### PR DESCRIPTION
Ajoute le lien vers l'interface d'entraînement IA (`training-interface.html`) **juste après** le lien « Lancer la Simulation » dans le README, au même format.

```markdown
- [Lancer la Simulation](https://habib256.github.io/pocketcosmos/index.html)
  _(Cliquez pour essayer !)_ ✨
- [Interface d'Entraînement IA](https://habib256.github.io/pocketcosmos/training-interface.html)
  _(Entraîner l'IA à piloter de A vers B !)_ 🤖
```

https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pCP4Q9hWVxPv5HRQsvnm)_